### PR TITLE
Fix documentation repository link in glossary.md

### DIFF
--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -94,4 +94,4 @@ A comprehensive list of technical terms used throughout the 0G documentation.
 
 ---
 
-*This glossary is continuously updated as the 0G ecosystem evolves. If you encounter a term not listed here, please contribute by submitting a pull request to our [documentation repository](https://github.com/0glabs/0g-docs).*
+*This glossary is continuously updated as the 0G ecosystem evolves. If you encounter a term not listed here, please contribute by submitting a pull request to our [documentation repository](https://github.com/0glabs/0g-doc).*


### PR DESCRIPTION
Fixed typo in repository URL by updating from /0glabs/0g-docs to /0glabs/0g-doc to match the correct documentation repository path.
Simple documentation link correction to ensure proper redirection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/167)
<!-- Reviewable:end -->
