### PR TITLE
Remove obsolete link

### DIFF
--- a/docs/run-a-node/community-docker-repo.md
+++ b/docs/run-a-node/community-docker-repo.md
@@ -11,6 +11,3 @@ Below is a list of community-maintained Docker images for 0G DA. Please note tha
 
 ### All Node Types
 [Ember Stake](https://docs.emberstake.xyz/networks/zero-gravity/nodes-guide/getting-started)
-
-### Validator Node
-[CryptoWarden](https://medium.com/@CryptoWarden/guide-to-running-a-node-in-the-0g-labs-project-0g-ai-1bee56ea53ca)


### PR DESCRIPTION
The CryptoWarden guide hasn’t been updated in over a year and still references the deprecated testnet Newton instead of Galileo. I propose removing it to avoid confusion for newcomers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/188)
<!-- Reviewable:end -->
