### PR TITLE
fix: update CI workflow after yarn.lock removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,19 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-        cache: 'yarn'
-    
+
     - name: Install dependencies
-      run: yarn install --frozen-lockfile
-    
+      run: yarn install
+
     - name: Lint code
       run: |
         if [ -f "package.json" ] && grep -q '"lint"' package.json; then
@@ -31,7 +30,7 @@ jobs:
         else
           echo "No lint script found, skipping..."
         fi
-    
+
     - name: Type check
       run: |
         if [ -f "tsconfig.json" ]; then
@@ -39,10 +38,10 @@ jobs:
         else
           echo "No TypeScript config found, skipping type check..."
         fi
-    
+
     - name: Build documentation
       run: yarn build
-    
+
     - name: Test build output
       run: |
         if [ ! -d "build" ]; then
@@ -59,38 +58,38 @@ jobs:
     name: Check Links
     runs-on: ubuntu-latest
     needs: build-and-test
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
         cache: 'yarn'
-    
+
     - name: Install dependencies
       run: yarn install --frozen-lockfile
-    
+
     - name: Build site
       run: yarn build
-    
+
     - name: Serve site and check links
       run: |
         # Install link checker
         npm install -g broken-link-checker
-        
+
         # Start server in background
         npx http-server build -p 3000 &
         SERVER_PID=$!
-        
+
         # Wait for server to start
         sleep 10
-        
+
         # Check internal links only
         blc http://localhost:3000 --recursive --exclude-external || echo "Some links may be broken, please review"
-        
+
         # Kill server
         kill $SERVER_PID
 
@@ -98,11 +97,11 @@ jobs:
   spell-check:
     name: Spell Check
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    
+
     - name: Spell check
       uses: streetsidesoftware/cspell-action@v6
       with:


### PR DESCRIPTION
# Pull Request

## Description
Fix CI workflow after yarn.lock was removed.
- Removed cache: yarn from setup-node
- Dropped --frozen-lockfile since no yarn.lock exists
- Ensures install step runs with plain yarn install

## Related Issue
Fixes #<!-- issue number -->

## Type of Change
- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [X] Tested locally with `yarn start`
- [X] Build passes with `yarn build`
- [ ] Links work correctly

## Checklist
- [X] Self-reviewed changes
- [X] No typos or errors
- [X] Follows project style
- [X] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/204)
<!-- Reviewable:end -->
