### PR TITLE
fix: lottie animation not visible clearly in dark mode

### DIFF
--- a/src/components/lottieAnimation.tsx
+++ b/src/components/lottieAnimation.tsx
@@ -2,8 +2,16 @@ import { LottieProps } from "@lottielab/lottie-player/react";
 import React, { useEffect, useState } from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import { ILottie } from "@lottielab/lottie-player";
+import { useColorMode } from "@docusaurus/theme-common";
+
+// TOD0: Replace these URLs with your actual themed animation URLs
+const LOTTIE_URLS = {
+  dark: "https://lottie.host/bc4266d9-d196-43c1-b81c-41e379c63b1b/UD7HLlauIo.json",
+  light: "https://cdn.lottielab.com/l/3cp3bJwTzHxWRS.json",
+};
 
 const LottieAnimation = () => {
+  const { colorMode } = useColorMode();
   const [LottieComponent, setLottieComponent] =
     useState<React.ForwardRefExoticComponent<
       LottieProps & React.RefAttributes<ILottie>
@@ -15,12 +23,18 @@ const LottieAnimation = () => {
     });
   }, []);
 
+  const getAnimationSrc = () => {
+    return colorMode === "dark"
+      ? LOTTIE_URLS.dark
+      : LOTTIE_URLS.light;
+  };
+
   return (
     <BrowserOnly>
       {() =>
         LottieComponent ? (
           <LottieComponent
-            src="https://cdn.lottielab.com/l/3cp3bJwTzHxWRS.json"
+            src={getAnimationSrc()}
             autoplay
           />
         ) : null


### PR DESCRIPTION
# Pull Request

## Description
The lottie animation at the end of [this](https://docs.0g.ai/introduction/understanding-0g) page is not clearly visible so urge the team to create another lottie and update it in this PR

## Related Issue
Fixes #203 

## Type of Change
- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [x] Tested locally with `yarn start`
- [x] Build passes with `yarn build`
- [x] Links work correctly

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/206)
<!-- Reviewable:end -->
