### PR TITLE
fix: correct Node.js version prerequisite to >= 20.0.0

### DIFF
--- a/docs/developer-hub/building-on-0g/compute-network/account-management.md
+++ b/docs/developer-hub/building-on-0g/compute-network/account-management.md
@@ -41,7 +41,7 @@ The account system provides a secure and flexible way to manage funds across dif
 
 ## Prerequisites
 
-- Node.js >= 22.0.0
+- Node.js >= 20.0.0
 - A wallet with 0G tokens (for testnet or mainnet)
 - EVM compatible wallet (for Web UI)
 

--- a/docs/developer-hub/building-on-0g/compute-network/inference.md
+++ b/docs/developer-hub/building-on-0g/compute-network/inference.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 ## Prerequisites
 
-- Node.js >= 22.0.0
+- Node.js >= 20.0.0
 - A wallet with 0G tokens (either testnet or mainnet)
 - EVM compatible wallet (for Web UI)
 


### PR DESCRIPTION
## Summary

- Fixed Node.js version prerequisite from `>= 22.0.0` to `>= 20.0.0` in two compute network docs pages

## Why

The SDK's `package.json` engines field specifies `>=20.0.0`, and this was already corrected in the SDK README via PR #172. The docs pages still had the old `22.0.0` requirement, which could cause confusion for developers using Node.js 20.x or 21.x.

## Files changed

| File | Change |
|------|--------|
| `docs/.../compute-network/inference.md` | Line 16: `22.0.0` → `20.0.0` |
| `docs/.../compute-network/account-management.md` | Line 44: `22.0.0` → `20.0.0` |

## Verification

- Confirmed against SDK `package.json` (`>=20.0.0`) and merged PR #172 README fix
- Searched all docs for remaining `22.0.0` references — none found

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/252)
<!-- Reviewable:end -->
