### PR TITLE
Expand authentication docs: inference vs management keys

### DIFF
--- a/docs/developer-hub/building-on-0g/compute-network/router/account/deposits.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/account/deposits.md
@@ -44,9 +44,11 @@ Tiered pricing for cached prompt tokens is on the roadmap — a future release w
 
 ## Check Your Balance
 
+`/v1/account/*` endpoints require a **management key** with the `account:read` scope (see [Authentication](../authentication)) — `sk-` keys return `403 insufficient_scope`.
+
 ```bash
 curl https://router-api.0g.ai/v1/account/balance \
-  -H "Authorization: Bearer sk-YOUR_API_KEY"
+  -H "Authorization: Bearer mk-YOUR_MANAGEMENT_KEY"
 ```
 
 ```json
@@ -65,7 +67,7 @@ Aggregate stats:
 
 ```bash
 curl "https://router-api.0g.ai/v1/account/usage/stats?start_date=2026-04-01" \
-  -H "Authorization: Bearer sk-YOUR_API_KEY"
+  -H "Authorization: Bearer mk-YOUR_MANAGEMENT_KEY"
 ```
 
 Returns total requests, total tokens (prompt/completion split), and total cost for the window.
@@ -74,7 +76,7 @@ Per-request history:
 
 ```bash
 curl "https://router-api.0g.ai/v1/account/usage/history?limit=20&offset=0" \
-  -H "Authorization: Bearer sk-YOUR_API_KEY"
+  -H "Authorization: Bearer mk-YOUR_MANAGEMENT_KEY"
 ```
 
 Returns a paginated list of individual requests with model, provider address, token counts, and cost. Both endpoints also accept `api_key_id`, `source`, `start_date`, and `end_date` filters.

--- a/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
@@ -23,10 +23,10 @@ Authorization: Bearer sk-YOUR_API_KEY
 ```
 
 ```
-Authorization: Bearer mk-YOUR_API_KEY
+Authorization: Bearer mk-YOUR_MANAGEMENT_KEY
 ```
 
-No OAuth flow, no wallet signature per request, no session tokens.
+No OAuth flow, no wallet signature per request, no session tokens. For the full request / response shape of every endpoint, see the **[Router API reference](https://0gfoundation.github.io/0g-router/)**.
 
 ## Permission matrix
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
@@ -48,7 +48,7 @@ One table covers what each credential can do and what scope it needs. `✅` = al
 
 Two guardrails worth calling out:
 
-- **Management keys cannot manage other management keys.** `*/v1/management-keys` requires the wallet JWT (sign-in session). A leaked `mk-` cannot mint replacements for itself.
+- **Management keys cannot manage other management keys.** `ANY /v1/management-keys/*` requires the wallet JWT (sign-in session). A leaked `mk-` cannot mint replacements for itself.
 - **`keys:manage` and `keys:create` are deliberately split.** A read-only audit integration that should be able to revoke a compromised key but **not** issue replacements gets `{keys:read, keys:manage}` and is locked out of issuance.
 
 ## API keys (`sk-`)

--- a/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
@@ -2,25 +2,21 @@
 id: authentication
 title: Authentication
 sidebar_position: 6
-description: "API keys are how you authenticate with the 0G Compute Router. Inference keys (sk-) call models; management keys (mk-) administer your account."
+description: "API keys (sk-) call models; management keys (mk-) administer your account. Send either in the Authorization header."
 ---
 
 # Authentication
 
-The Router authenticates every request with an **API key**. Each key is tied to your wallet address; inference usage is billed against the 0G tokens you deposited to the [Payment Layer](./account/deposits).
+The Router accepts two kinds of credentials, distinguished by prefix:
 
-There are **two kinds of keys**, with different prefixes and different powers:
+| Key type           | Prefix | What it's for                                                                                 |
+| ------------------ | ------ | --------------------------------------------------------------------------------------------- |
+| **API key**        | `sk-`  | Call inference endpoints (`/v1/chat/completions`, etc.). Billed against your deposit.         |
+| **Management key** | `mk-`  | Administer your account: list / create / revoke API keys, read balance and usage. Not billed. |
 
-| Key type             | Prefix | What it can do                                                                                     |
-| -------------------- | ------ | -------------------------------------------------------------------------------------------------- |
-| **Inference key**    | `sk-`  | Call inference endpoints (`/v1/chat/completions`, etc.). Billed against your deposit.              |
-| **Management key**   | `mk-`  | Administer your account: list / create / revoke inference keys, read balance and usage. Not billed. |
+Ship `sk-` keys to the runtime that actually calls models; use `mk-` keys for dashboards, audit integrations, and CI that needs to provision or rotate API keys.
 
-Pick the right one for the job: ship `sk-` keys to the runtime that actually calls models; use `mk-` keys for dashboards, audit integrations, and CI that needs to provision or rotate inference keys.
-
-## Sending the key
-
-Send the key in the `Authorization` header on every request — same shape for both kinds:
+Both kinds go in the `Authorization` header — same shape:
 
 ```
 Authorization: Bearer sk-YOUR_API_KEY
@@ -30,89 +26,48 @@ Authorization: Bearer sk-YOUR_API_KEY
 Authorization: Bearer mk-YOUR_API_KEY
 ```
 
-That's the whole protocol — no OAuth flow, no wallet signature per request, no session tokens.
+No OAuth flow, no wallet signature per request, no session tokens.
 
-## Inference keys (`sk-`)
+## Permission matrix
 
-Inference keys are what your application servers carry. Each call to `/v1/chat/completions` (and the other inference endpoints) is billed against the depositing wallet's balance.
+One table covers what each credential can do and what scope it needs. `✅` = allowed, `❌` = `403 insufficient_scope`.
 
-Create and manage them in the Web UI: **[pc.0g.ai](https://pc.0g.ai) → Dashboard → API Keys**. From there you can:
+| Scenario                       | Endpoint                            | `sk-` API key | `mk-` Management key   |
+| ------------------------------ | ----------------------------------- | :-----------: | ---------------------- |
+| Run inference                  | `POST /v1/chat/completions` (etc.)  |       ✅      | ❌                      |
+| Read balance / usage / history | `GET /v1/account/*`                 |       ❌      | ✅ `account:read`       |
+| List API keys                  | `GET /v1/api-keys`                  |       ❌      | ✅ `keys:read`          |
+| Create API key                 | `POST /v1/api-keys`                 |       ❌      | ✅ `keys:create`        |
+| Edit / revoke API key          | `PATCH`/`DELETE /v1/api-keys/:id`   |       ❌      | ✅ `keys:manage`        |
+| Manage management keys         | `*/v1/management-keys`              |       ❌      | ❌ — wallet JWT only    |
+
+Two guardrails worth calling out:
+
+- **Management keys cannot manage other management keys.** `*/v1/management-keys` requires the wallet JWT (sign-in session). A leaked `mk-` cannot mint replacements for itself.
+- **`keys:manage` and `keys:create` are deliberately split.** A read-only audit integration that should be able to revoke a compromised key but **not** issue replacements gets `{keys:read, keys:manage}` and is locked out of issuance.
+
+## API keys (`sk-`)
+
+Created at **[pc.0g.ai](https://pc.0g.ai) → Dashboard → API Keys**. From there you can:
 
 - **Create** a new key — label it so you can tell keys apart (e.g. `staging`, `agent-bot`, `my-laptop`). The full secret is shown **once** on creation; copy it immediately. The dashboard only stores a hash.
 - **List** existing keys with their labels, created-at, and last-used timestamps.
 - **Revoke** any key instantly — in-flight requests using a revoked key return `401 api_key_revoked` on their next call.
 
-Inference keys can only call inference endpoints. They **cannot** read `/v1/account/*` (balance, usage, history) and they **cannot** manage other keys — those calls return `403 insufficient_scope`. Use a management key (or your wallet JWT) for that.
-
 ## Management keys (`mk-`)
 
-Management keys are scope-based admin credentials. Instead of a single permission level, each key carries an explicit allowlist of scopes — grant only what the integration needs.
+Created at **[pc.0g.ai → Settings → Management Keys](https://pc.0g.ai)**. Each key carries an explicit allowlist of scopes — see the matrix above.
 
-### Scopes
-
-| Scope            | Grants                                                            | Risk     |
-| ---------------- | ----------------------------------------------------------------- | -------- |
-| `account:read`   | Read balance, usage, and history (`GET /v1/account/*`)            | Low      |
-| `keys:read`      | List inference keys (`GET /v1/api-keys`)                          | Low      |
-| `keys:manage`    | Edit or revoke existing inference keys (`PATCH`/`DELETE`)         | **High** |
-| `keys:create`    | Issue new inference keys (`POST /v1/api-keys`)                    | **High** |
-
-The split between `keys:manage` and `keys:create` is deliberate. A read-only audit integration that should be able to revoke a compromised key but **not** issue replacements gets `{keys:read, keys:manage}` and is locked out of issuance.
-
-### Presets
-
-The Web UI offers four presets when you create a management key — pick one or check scopes individually:
+When creating a key, pick a preset or check scopes individually:
 
 - **Read-only** — `account:read`, `keys:read`. Dashboards, monitoring.
 - **Key Manager** — `keys:read`, `keys:manage`. Rotate / revoke existing keys, no issuance.
-- **Full Admin** — all four scopes. CI that provisions per-deploy inference keys.
+- **Full Admin** — all four scopes. CI that provisions per-deploy API keys.
 - **Custom** — pick any subset.
 
-### Create and manage
+**Audit fields.** Every successful request with an `mk-` key updates `last_used_at` and `last_source_ip` on the key. Writes are coalesced to at most one per key per 60 seconds. IPv4-mapped IPv6 addresses (`::ffff:1.2.3.4`) are normalized to dotted-quad so a dual-stack vs IPv4-only listener doesn't make one client look like two. (`sk-` keys don't record these — their audit signal is usage / billing.)
 
-Management keys are created at **[pc.0g.ai](https://pc.0g.ai) → Settings → Management Keys**.
-
-- **Create** — name the key, pick scopes (or a preset). The full `mk-…` secret is shown **once**; copy it immediately.
-- **Inspect** — click a row to expand the detail panel: key prefix, created-at, last-used-at, last source IP, and the full permission matrix.
-- **Edit** — rename or change scopes in place. Only changed fields are sent on the wire.
-- **Revoke** — instant. The next call with that key returns `401`.
-
-### What you can hit with `mk-`
-
-| Endpoint                              | Required scope                  |
-| ------------------------------------- | ------------------------------- |
-| `GET /v1/account/*`                   | `account:read`                  |
-| `GET /v1/api-keys`                    | `keys:read`                     |
-| `POST /v1/api-keys`                   | `keys:create`                   |
-| `PATCH /v1/api-keys/:id`              | `keys:manage`                   |
-| `DELETE /v1/api-keys/:id`             | `keys:manage`                   |
-| `POST /v1/chat/completions` (etc.)    | — **denied**, use an `sk-` key  |
-| `*/v1/management-keys`                | — **denied**, use the wallet JWT |
-
-Two guardrails worth calling out:
-
-- **Management keys cannot manage other management keys.** All four `*/v1/management-keys` endpoints require the wallet JWT (sign-in session). This blocks privilege escalation — a leaked `mk-` cannot mint replacements for itself.
-- **Management keys cannot call inference.** They return `403` on `/v1/chat/completions` and friends. Mixing audit credentials with billed traffic was never the intent.
-
-### Audit fields
-
-Every successful request with an `mk-` key updates **`last_used_at`** and **`last_source_ip`** on the key. Writes are coalesced to at most one per key per 60 seconds, so a polling integration doesn't generate a write per request. IPv4-mapped IPv6 addresses (`::ffff:1.2.3.4`) are normalized to dotted-quad before storage so a dual-stack vs IPv4-only listener doesn't make one client look like two.
-
-Inference keys do **not** record these fields — for `sk-` keys the audit signal is usage / billing.
-
-### Expiration
-
-Management keys do not expire and the HTTP surface does not accept an expiration. Rotate them on a schedule by issuing a replacement and revoking the old key.
-
-## Picking the right credential
-
-| You want to…                                            | Use                                       |
-| ------------------------------------------------------- | ----------------------------------------- |
-| Call `/v1/chat/completions` from your backend           | `sk-` inference key                       |
-| Read balance / usage from a monitoring job              | `mk-` with `account:read`                 |
-| Auto-provision per-tenant inference keys from CI        | `mk-` with `keys:create` (+ `keys:read`)  |
-| Auto-revoke leaked keys from a security-monitoring job  | `mk-` with `keys:read` + `keys:manage`    |
-| Manage management keys themselves                       | Wallet sign-in (JWT) at pc.0g.ai          |
+**Expiration.** Management keys do not expire. Rotate on a schedule by issuing a replacement and revoking the old key.
 
 ## Best practices
 
@@ -121,6 +76,6 @@ Management keys do not expire and the HTTP surface does not accept an expiration
 - **Rotate on suspicion.** If a key might have leaked, revoke it and issue a new one — takes seconds.
 - **Watch `last_used_at` on management keys.** A key that hasn't been used in months is a key you can probably revoke.
 
-:::caution Never ship API keys to browsers
-Whoever has your inference key can spend the 0G tokens you deposited; whoever has your management key can issue more inference keys. Keep both server-side and proxy client requests through your own backend — your backend holds the key, your frontend talks to your backend.
+:::caution Never ship keys to browsers
+Whoever has your `sk-` key can spend the 0G tokens you deposited; whoever has your `mk-` key can issue more `sk-` keys. Keep both server-side and proxy client requests through your own backend.
 :::

--- a/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
@@ -33,7 +33,7 @@ No OAuth flow, no wallet signature per request, no session tokens. For the full 
 One table covers what each credential can do and what scope it needs. `✅` = allowed, `❌` = `403 insufficient_scope`.
 
 | Scenario                       | Endpoint                            | `sk-` API key | `mk-` Management key   |
-| ------------------------------ | ----------------------------------- | :-----------: | ---------------------- |
+| ------------------------------ | ----------------------------------- | :-----------: | :--------------------- |
 | Run inference                  | `POST /v1/chat/completions` (etc.)  |       ✅      | ❌                      |
 | Read balance / usage / history | `GET /v1/account/*`                 |       ❌      | ✅ `account:read`       |
 | List API keys                  | `GET /v1/api-keys`                  |       ❌      | ✅ `keys:read`          |

--- a/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
@@ -39,7 +39,7 @@ One table covers what each credential can do and what scope it needs. `✅` = al
 | List API keys                  | `GET /v1/api-keys`                  |       ❌      | ✅ `keys:read`          |
 | Create API key                 | `POST /v1/api-keys`                 |       ❌      | ✅ `keys:create`        |
 | Edit / revoke API key          | `PATCH`/`DELETE /v1/api-keys/:id`   |       ❌      | ✅ `keys:manage`        |
-| Manage management keys         | `*/v1/management-keys`              |       ❌      | ❌ — wallet JWT only    |
+| Manage management keys         | `ANY /v1/management-keys/*`         |       ❌      | ❌ — wallet JWT only    |
 
 Two guardrails worth calling out:
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
@@ -7,6 +7,11 @@ description: "API keys (sk-) call models; management keys (mk-) administer your 
 
 # Authentication
 
+:::caution Breaking change (existing users)
+`sk-` keys no longer have access to `/v1/account/*` (balance, usage, history).
+Issue an `mk-` key with the `account:read` scope and update your dashboard / billing code.
+:::
+
 The Router accepts two kinds of credentials, distinguished by prefix:
 
 | Key type           | Prefix | What it's for                                                                                 |

--- a/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
@@ -2,40 +2,146 @@
 id: authentication
 title: Authentication
 sidebar_position: 6
-description: "API keys are how you authenticate with the 0G Compute Router. Create them in the Web UI; send them in the Authorization header."
+description: "API keys are how you authenticate with the 0G Compute Router. Inference keys (sk-) call models; management keys (mk-) administer your account."
 ---
 
 # Authentication
 
-The Router authenticates every request with an **API Key**. Each key is tied to your wallet address; usage is billed against the 0G tokens you deposited to the [Payment Layer](./account/deposits).
+The Router authenticates every request with an **API key**. Each key is tied to your wallet address; inference usage is billed against the 0G tokens you deposited to the [Payment Layer](./account/deposits).
+
+There are **two kinds of keys**, with different prefixes and different powers:
+
+| Key type             | Prefix | What it can do                                                                                     |
+| -------------------- | ------ | -------------------------------------------------------------------------------------------------- |
+| **Inference key**    | `sk-`  | Call inference endpoints (`/v1/chat/completions`, etc.). Billed against your deposit.              |
+| **Management key**   | `mk-`  | Administer your account: list / create / revoke inference keys, read balance and usage. Not billed. |
+
+Pick the right one for the job: ship `sk-` keys to the runtime that actually calls models; use `mk-` keys for dashboards, audit integrations, and CI that needs to provision or rotate inference keys.
 
 ## Sending the key
 
-Send the key in the `Authorization` header on every request:
+Send the key in the `Authorization` header on every request — same shape for both kinds:
 
 ```
-Authorization: Bearer sk-YOUR_API_KEY
+Authorization: Bearer sk-YOUR_INFERENCE_KEY
+```
+
+```
+Authorization: Bearer mk-YOUR_MANAGEMENT_KEY
 ```
 
 That's the whole protocol — no OAuth flow, no wallet signature per request, no session tokens.
 
-## Create and manage keys
+## Inference keys (`sk-`)
 
-API keys are created and managed in the Web UI: **[pc.0g.ai](https://pc.0g.ai) → Dashboard → API Keys**. From there you can:
+Inference keys are what your application servers carry. Each call to `/v1/chat/completions` (and the other inference endpoints) is billed against the depositing wallet's balance.
+
+Create and manage them in the Web UI: **[pc.0g.ai](https://pc.0g.ai) → Dashboard → API Keys**. From there you can:
 
 - **Create** a new key — label it so you can tell keys apart (e.g. `staging`, `agent-bot`, `my-laptop`). The full secret is shown **once** on creation; copy it immediately. The dashboard only stores a hash.
 - **List** existing keys with their labels, created-at, and last-used timestamps.
 - **Revoke** any key instantly — in-flight requests using a revoked key return `401 api_key_revoked` on their next call.
 
+Inference keys can only call inference endpoints. They **cannot** read `/v1/account/*` (balance, usage, history) and they **cannot** manage other keys — those calls return `403 insufficient_scope`. Use a management key (or your wallet JWT) for that.
+
+## Management keys (`mk-`)
+
+Management keys are scope-based admin credentials. Instead of a single permission level, each key carries an explicit allowlist of scopes — grant only what the integration needs.
+
+### Scopes
+
+| Scope            | Grants                                                            | Risk     |
+| ---------------- | ----------------------------------------------------------------- | -------- |
+| `account:read`   | Read balance, usage, and history (`GET /v1/account/*`)            | Low      |
+| `keys:read`      | List inference keys (`GET /v1/api-keys`)                          | Low      |
+| `keys:manage`    | Edit or revoke existing inference keys (`PATCH`/`DELETE`)         | **High** |
+| `keys:create`    | Issue new inference keys (`POST /v1/api-keys`)                    | **High** |
+
+The split between `keys:manage` and `keys:create` is deliberate. A read-only audit integration that should be able to revoke a compromised key but **not** issue replacements gets `{keys:read, keys:manage}` and is locked out of issuance.
+
+### Presets
+
+The Web UI offers four presets when you create a management key — pick one or check scopes individually:
+
+- **Read-only** — `account:read`, `keys:read`. Dashboards, monitoring.
+- **Key Manager** — `keys:read`, `keys:manage`. Rotate / revoke existing keys, no issuance.
+- **Full Admin** — all four scopes. CI that provisions per-deploy inference keys.
+- **Custom** — pick any subset.
+
+### Create and manage
+
+Management keys are created at **[pc.0g.ai](https://pc.0g.ai) → Settings → Management Keys**.
+
+- **Create** — name the key, pick scopes (or a preset). The full `mk-…` secret is shown **once**; copy it immediately.
+- **Inspect** — click a row to expand the detail panel: key prefix, created-at, last-used-at, last source IP, and the full permission matrix.
+- **Edit** — rename or change scopes in place. Only changed fields are sent on the wire.
+- **Revoke** — instant. The next call with that key returns `401`.
+
+### What you can hit with `mk-`
+
+| Endpoint                              | Required scope                  |
+| ------------------------------------- | ------------------------------- |
+| `GET /v1/account/*`                   | `account:read`                  |
+| `GET /v1/api-keys`                    | `keys:read`                     |
+| `POST /v1/api-keys`                   | `keys:create`                   |
+| `PATCH /v1/api-keys/:id`              | `keys:manage`                   |
+| `DELETE /v1/api-keys/:id`             | `keys:manage`                   |
+| `POST /v1/chat/completions` (etc.)    | — **denied**, use an `sk-` key  |
+| `*/v1/management-keys`                | — **denied**, use the wallet JWT |
+
+Two guardrails worth calling out:
+
+- **Management keys cannot manage other management keys.** All four `*/v1/management-keys` endpoints require the wallet JWT (sign-in session). This blocks privilege escalation — a leaked `mk-` cannot mint replacements for itself.
+- **Management keys cannot call inference.** They return `403` on `/v1/chat/completions` and friends. Mixing audit credentials with billed traffic was never the intent.
+
+### Audit fields
+
+Every successful request with an `mk-` key updates **`last_used_at`** and **`last_source_ip`** on the key. Writes are coalesced to at most one per key per 60 seconds, so a polling integration doesn't generate a write per request. IPv4-mapped IPv6 addresses (`::ffff:1.2.3.4`) are normalised to dotted-quad before storage so a dual-stack vs IPv4-only listener doesn't make one client look like two.
+
+Inference keys do **not** record these fields — for `sk-` keys the audit signal is usage / billing.
+
+### Expiration
+
+Management keys do not expire and the HTTP surface does not accept an expiration. Rotate them on a schedule by issuing a replacement and revoking the old key.
+
+## Picking the right credential
+
+| You want to…                                            | Use                                       |
+| ------------------------------------------------------- | ----------------------------------------- |
+| Call `/v1/chat/completions` from your backend           | `sk-` inference key                       |
+| Read balance / usage from a monitoring job              | `mk-` with `account:read`                 |
+| Auto-provision per-tenant inference keys from CI        | `mk-` with `keys:create` (+ `keys:read`)  |
+| Auto-revoke leaked keys from a SIEM integration         | `mk-` with `keys:read` + `keys:manage`    |
+| Manage management keys themselves                       | Wallet sign-in (JWT) at pc.0g.ai          |
+
+## Breaking change — `sk-` keys lost access to `/v1/account/*`
+
+Previously inference keys could read `/v1/account/balance`, `/v1/account/usage`, etc. They no longer can — those endpoints now return:
+
+```json
+{
+  "error": {
+    "message": "this credential is not allowed to access account endpoints",
+    "type": "auth_error",
+    "code": "insufficient_scope"
+  }
+}
+```
+
+with HTTP `403`. To restore the call, swap the `sk-` for either:
+
+- a management key with `account:read`, or
+- a wallet JWT (sign-in session — what the Web UI uses).
+
+Inference endpoints (`/v1/chat/completions`, etc.) are unchanged; existing `sk-` keys keep working there.
+
 ## Best practices
 
 - **One key per deployment.** Separate staging / production / per-service keys so you can revoke one without touching the others.
+- **Least privilege for `mk-`.** Don't grant `keys:create` to an integration that only needs to read. The preset selector is there for a reason.
 - **Rotate on suspicion.** If a key might have leaked, revoke it and issue a new one — takes seconds.
+- **Watch `last_used_at` on management keys.** A key that hasn't been used in months is a key you can probably revoke.
 
 :::caution Never ship API keys to browsers
-Whoever has your key can spend the 0G tokens you deposited. Keep keys server-side and proxy client requests through your own backend — your backend holds the key, your frontend talks to your backend.
-:::
-
-:::info Coming soon
-Per-key controls such as **permission scopes**, **expiration**, and **per-key rate / token limits** are on the roadmap. Today every key grants full inference access and does not expire.
+Whoever has your inference key can spend the 0G tokens you deposited; whoever has your management key can issue more inference keys. Keep both server-side and proxy client requests through your own backend — your backend holds the key, your frontend talks to your backend.
 :::

--- a/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
@@ -23,11 +23,11 @@ Pick the right one for the job: ship `sk-` keys to the runtime that actually cal
 Send the key in the `Authorization` header on every request — same shape for both kinds:
 
 ```
-Authorization: Bearer sk-YOUR_INFERENCE_KEY
+Authorization: Bearer sk-YOUR_API_KEY
 ```
 
 ```
-Authorization: Bearer mk-YOUR_MANAGEMENT_KEY
+Authorization: Bearer mk-YOUR_API_KEY
 ```
 
 That's the whole protocol — no OAuth flow, no wallet signature per request, no session tokens.
@@ -96,7 +96,7 @@ Two guardrails worth calling out:
 
 ### Audit fields
 
-Every successful request with an `mk-` key updates **`last_used_at`** and **`last_source_ip`** on the key. Writes are coalesced to at most one per key per 60 seconds, so a polling integration doesn't generate a write per request. IPv4-mapped IPv6 addresses (`::ffff:1.2.3.4`) are normalised to dotted-quad before storage so a dual-stack vs IPv4-only listener doesn't make one client look like two.
+Every successful request with an `mk-` key updates **`last_used_at`** and **`last_source_ip`** on the key. Writes are coalesced to at most one per key per 60 seconds, so a polling integration doesn't generate a write per request. IPv4-mapped IPv6 addresses (`::ffff:1.2.3.4`) are normalized to dotted-quad before storage so a dual-stack vs IPv4-only listener doesn't make one client look like two.
 
 Inference keys do **not** record these fields — for `sk-` keys the audit signal is usage / billing.
 
@@ -111,29 +111,8 @@ Management keys do not expire and the HTTP surface does not accept an expiration
 | Call `/v1/chat/completions` from your backend           | `sk-` inference key                       |
 | Read balance / usage from a monitoring job              | `mk-` with `account:read`                 |
 | Auto-provision per-tenant inference keys from CI        | `mk-` with `keys:create` (+ `keys:read`)  |
-| Auto-revoke leaked keys from a SIEM integration         | `mk-` with `keys:read` + `keys:manage`    |
+| Auto-revoke leaked keys from a security-monitoring job  | `mk-` with `keys:read` + `keys:manage`    |
 | Manage management keys themselves                       | Wallet sign-in (JWT) at pc.0g.ai          |
-
-## Breaking change — `sk-` keys lost access to `/v1/account/*`
-
-Previously inference keys could read `/v1/account/balance`, `/v1/account/usage`, etc. They no longer can — those endpoints now return:
-
-```json
-{
-  "error": {
-    "message": "this credential is not allowed to access account endpoints",
-    "type": "auth_error",
-    "code": "insufficient_scope"
-  }
-}
-```
-
-with HTTP `403`. To restore the call, swap the `sk-` for either:
-
-- a management key with `account:read`, or
-- a wallet JWT (sign-in session — what the Web UI uses).
-
-Inference endpoints (`/v1/chat/completions`, etc.) are unchanged; existing `sk-` keys keep working there.
 
 ## Best practices
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/quickstart.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/quickstart.md
@@ -24,7 +24,7 @@ See [Deposits & Billing](./account/deposits) for how costs are calculated and ho
 
 ## 3. Create an API Key
 
-In **Dashboard → API Keys**, create a key with the `inference` permission. You'll get a secret starting with `sk-`.
+In **Dashboard → API Keys**, click **Create**. You'll get a secret starting with `sk-` — the API key used for inference calls. See [Authentication](./authentication) for the difference between `sk-` API keys and `mk-` management keys.
 
 Store it somewhere safe — the Router never shows it again.
 


### PR DESCRIPTION
## Description

Significantly expand the authentication documentation to clarify the two types of API keys and their distinct purposes:

- **Inference keys (`sk-`)**: For calling model endpoints, billed against deposits
- **Management keys (`mk-`)**: For account administration with granular scope-based permissions

Key additions:
- Detailed comparison table of key types and capabilities
- Complete scope documentation for management keys (account:read, keys:read, keys:manage, keys:create)
- Preset configurations for common use cases (read-only, key manager, full admin)
- Comprehensive endpoint permission matrix
- Audit field behavior (last_used_at, last_source_ip)
- Decision table for choosing the right credential type
- Breaking change notice: `sk-` keys can no longer access `/v1/account/*` endpoints
- Updated best practices including least-privilege guidance for management keys

This documentation update reflects the new two-tier authentication system and helps users understand when to use each key type.

## Related Issue

N/A

## Type of Change

- [x] Documentation update

## Testing

- [x] Tested locally with `yarn start`
- [x] Build passes with `yarn build`
- [x] Links work correctly

## Checklist

- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

https://claude.ai/code/session_01KYBiHSDRjptrvpUbdGAKdJ