### PR TITLE
fix(wallet): robust, multi-wallet, mobile-aware Add-Network buttons

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,7 @@
     "lottielab",
     "okxwallet",
     "rdns",
+    "subdeps",
     "wagmi",
     "0g",
     "0glabs",

--- a/.cspell.json
+++ b/.cspell.json
@@ -2,6 +2,11 @@
   "version": "0.2",
   "language": "en",
   "words": [
+    "deeplinking",
+    "lottielab",
+    "okxwallet",
+    "rdns",
+    "wagmi",
     "0g",
     "0glabs",
     "blockchain",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Docusaurus 3 site published at https://docs.0g.ai. Content lives in `docs/`; sit
 
 ## Commands
 
-Node 20.11.0 (`.nvmrc`). README uses `yarn`, but the committed lockfile is `pnpm-lock.yaml` and CI runs pnpm 9 — prefer pnpm to keep the lockfile clean.
+Node 24 (`.nvmrc`) and pnpm 11, **pinned via the `packageManager` field in `package.json`**. README still says `yarn`, but the committed lockfile is `pnpm-lock.yaml` — always use pnpm. Run `nvm use` (picks up `.nvmrc`) and `corepack enable` so the pinned pnpm activates automatically; CI reads the same `packageManager` pin via `pnpm/action-setup` (the workflow deliberately sets **no** `version:`, or it errors with `ERR_PNPM_BAD_PM_VERSION`).
 
 - `pnpm install --frozen-lockfile` — install (matches CI)
 - `pnpm start` — dev server with live reload
@@ -18,6 +18,13 @@ Node 20.11.0 (`.nvmrc`). README uses `yarn`, but the committed lockfile is `pnpm
 - `pnpm clear` — clear Docusaurus cache when builds get weird
 
 No test suite. CI validates by: build, broken-link check (see below), and cspell.
+
+### pnpm 10+ gotchas (`pnpm-workspace.yaml`)
+
+pnpm 10+ tightened two defaults that abort installs on this repo. Both are intentionally relaxed in `pnpm-workspace.yaml` — **don't delete that file or those keys** or `pnpm install`/`pnpm start` will break again:
+
+- `allowBuilds: { core-js: false, core-js-pure: false }` — these packages' only build step is a postinstall donation banner; without this, installs abort with `ERR_PNPM_IGNORED_BUILDS`. (pnpm regenerates an `allowBuilds:` placeholder with `"set this to true or false"` values when it hits this — fill in `false`, don't leave the placeholder.)
+- `blockExoticSubdeps: false` — `@lottielab/lottie-player` resolves `lottie-web` via a git URL, which pnpm 11 blocks by default.
 
 ### Reproducing the CI link check locally
 
@@ -65,6 +72,18 @@ keywords: [keyword1, keyword2]
 - `markdown-endpoint-plugin.js` — copies raw `.md`/`.mdx` files into the build output so `docs.0g.ai/concepts/compute.md` returns raw markdown. Used by LLM tooling. Also installs dev-server middleware so the same routes work under `pnpm start`.
 - `security-headers-plugin.js` — sets CSP, X-Frame-Options, HSTS, etc. on the dev server. Production headers are set in `static/_headers` (Vercel) and `vercel.json`.
 - `docusaurus-plugin-llms` — generates `llms.txt` and `llms-full.txt` at the site root from the docs corpus.
+
+### Wallet buttons (`src/components/`)
+
+`MetaMaskButton` and `OKXButton` render the "Add 0G network" buttons on the testnet/mainnet docs pages. They are **deliberately dependency-free** (no wagmi/viem/MetaMask SDK) — appropriate for a docs site whose only wallet feature is a one-click add-network. Keep them that way unless mobile UX becomes a priority, at which point the MetaMask Connect SDK (proper deeplinking/session management) is the upgrade trigger — not wagmi.
+
+`MetaMaskButton` invariants worth preserving (each fixes a real, audited failure mode — don't "simplify" them away):
+
+- Resolves the genuine MetaMask provider via **EIP-6963** (`rdns: io.metamask`), not raw `window.ethereum` — other wallets (OKX, Brave, Coinbase) overwrite it and set `isMetaMask = true` to impersonate. Legacy `window.ethereum.providers[]` / `isMetaMask` are fallbacks only, with impersonators excluded.
+- Follows MetaMask's official switch-then-add-on-`4902` pattern, and handles the documented error codes: `4902` (incl. the **nested mobile shape** `error.data.originalError.code`, plus a post-switch `eth_chainId` re-check because mobile can resolve a switch without switching), `4001` (user rejected), `-32002` (request pending). Feedback is an inline `aria-live` region — not `alert()`/`console.log`.
+- Mobile (no injected provider) falls back to a `https://link.metamask.io/dapp/<url>` deep link into the MetaMask in-app browser.
+
+`OKXButton` targets the namespaced `window.okxwallet`, so it doesn't collide with `window.ethereum`.
 
 ### Math and search
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,13 +77,11 @@ keywords: [keyword1, keyword2]
 
 `MetaMaskButton` and `OKXButton` render the "Add 0G network" buttons on the testnet/mainnet docs pages. They are **deliberately dependency-free** (no wagmi/viem/MetaMask SDK) — appropriate for a docs site whose only wallet feature is a one-click add-network. Keep them that way unless mobile UX becomes a priority, at which point the MetaMask Connect SDK (proper deeplinking/session management) is the upgrade trigger — not wagmi.
 
-`MetaMaskButton` invariants worth preserving (each fixes a real, audited failure mode — don't "simplify" them away):
+Shared, wallet-agnostic logic (chain-id formatting, nested-error-code unwrapping, mobile + in-app-webview detection) lives in `src/components/walletUtils.ts` — one source of truth for both buttons, so e.g. the social-webview list can't drift. Invariants worth preserving (each fixes a real, audited failure mode — don't "simplify" them away):
 
-- Resolves the genuine MetaMask provider via **EIP-6963** (`rdns: io.metamask`), not raw `window.ethereum` — other wallets (OKX, Brave, Coinbase) overwrite it and set `isMetaMask = true` to impersonate. Legacy `window.ethereum.providers[]` / `isMetaMask` are fallbacks only, with impersonators excluded.
-- Follows MetaMask's official switch-then-add-on-`4902` pattern, and handles the documented error codes: `4902` (incl. the **nested mobile shape** `error.data.originalError.code`, plus a post-switch `eth_chainId` re-check because mobile can resolve a switch without switching), `4001` (user rejected), `-32002` (request pending). Feedback is an inline `aria-live` region — not `alert()`/`console.log`.
-- Mobile (no injected provider) falls back to a `https://link.metamask.io/dapp/<url>` deep link into the MetaMask in-app browser.
-
-`OKXButton` targets the namespaced `window.okxwallet`, so it doesn't collide with `window.ethereum`.
+- **MetaMaskButton** resolves the genuine MetaMask provider via **EIP-6963** (`rdns: io.metamask`), not raw `window.ethereum` — other wallets (OKX, Brave, Coinbase) overwrite it and set `isMetaMask = true` to impersonate. Legacy `window.ethereum.providers[]` / `isMetaMask` are fallbacks only, with impersonators excluded. **OKXButton** needs none of this — it targets the namespaced `window.okxwallet`, so there's no `window.ethereum` collision to disambiguate.
+- Both follow MetaMask's official switch-then-add-on-`4902` pattern and handle the documented error codes: `4902` (incl. the **nested mobile shape** `error.data.originalError.code`, plus a post-switch `eth_chainId` re-check because mobile can resolve a switch without switching), `4001` (user rejected), `-32002` (request pending). Feedback is an inline `aria-live` region with an in-flight (`disabled`/`aria-busy`) guard — not `alert()`/`console.log`.
+- Mobile (no injected provider) falls back to a deep link into the wallet's in-app browser — `https://link.metamask.io/dapp/<url>` for MetaMask, OKX's `okx://wallet/dapp/url` universal link for OKX. Detected social in-app webviews (where universal-link handoff is unreliable) instead show "open in your default browser" guidance.
 
 ### Math and search
 

--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -16,7 +16,7 @@ This page provides comprehensive context about 0G infrastructure to help AI codi
 
 | Parameter | Value |
 |-----------|-------|
-| **Network Name** | 0G-Galileo-Testnet |
+| **Network Name** | 0G Galileo Testnet |
 | **Chain ID** | 16602 |
 | **Token Symbol** | 0G |
 | **RPC Endpoint** | https://evmrpc-testnet.0g.ai (development only — use 3rd party RPCs for production) |
@@ -725,8 +725,8 @@ Curated list of community projects, tools, and resources built on 0G.
 await window.ethereum.request({
   method: 'wallet_addEthereumChain',
   params: [{
-    chainId: '0x40EA',
-    chainName: '0G-Galileo-Testnet',
+    chainId: '0x40DA',
+    chainName: '0G Galileo Testnet',
     nativeCurrency: { name: '0G', symbol: '0G', decimals: 18 },
     rpcUrls: ['https://evmrpc-testnet.0g.ai'],
     blockExplorerUrls: ['https://chainscan-galileo.0g.ai']
@@ -739,7 +739,7 @@ await window.ethereum.request({
 await window.ethereum.request({
   method: 'wallet_addEthereumChain',
   params: [{
-    chainId: '0x4125',
+    chainId: '0x4115',
     chainName: '0G Mainnet',
     nativeCurrency: { name: '0G', symbol: '0G', decimals: 18 },
     rpcUrls: ['https://evmrpc.0g.ai'],

--- a/docs/developer-hub/mainnet/mainnet-overview.md
+++ b/docs/developer-hub/mainnet/mainnet-overview.md
@@ -44,7 +44,7 @@ Build and run production workloads on the 0G Mainnet.
     tokenSymbol="0G"
     tokenDecimals={18}
     rpcUrls={["https://evmrpc.0g.ai"]}
-    blockExplorerUrls={["https://chainscan.0g.ai/"]}
+    blockExplorerUrls={["https://chainscan.0g.ai"]}
   />
   <OKXButton
     label="Add 0G Mainnet"
@@ -54,7 +54,7 @@ Build and run production workloads on the 0G Mainnet.
     tokenSymbol="0G"
     tokenDecimals={18}
     rpcUrls={["https://evmrpc.0g.ai"]}
-    blockExplorerUrls={["https://chainscan.0g.ai/"]}
+    blockExplorerUrls={["https://chainscan.0g.ai"]}
   />
 </div>
 

--- a/docs/developer-hub/testnet/testnet-overview.md
+++ b/docs/developer-hub/testnet/testnet-overview.md
@@ -22,7 +22,7 @@ Test your applications on 0G's infrastructure without real costs or risks.
 
 | Parameters | Network Details |
 |----------------|---|
-| **Network Name** | 0G-Galileo-Testnet |
+| **Network Name** | 0G Galileo Testnet |
 | **Chain ID** | 16602 |
 | **Token Symbol** | 0G |
 | **Block Explorer** | ```https://chainscan-galileo.0g.ai``` |

--- a/docs/run-a-node/archival-node.md
+++ b/docs/run-a-node/archival-node.md
@@ -6,7 +6,7 @@ description: "Guide to running a 0G archival node for complete historical blockc
 # Archival Node
 ---
 
-Running an Archival node for the **0G-Galileo-Testnet** means providing complete historical data storage and access for the network, maintaining the full blockchain history and state.
+Running an Archival node for the **0G Galileo Testnet** means providing complete historical data storage and access for the network, maintaining the full blockchain history and state.
 
 :::info **What You'll Need**
 - Linux system with sufficient disk space for archive data

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -45,6 +45,25 @@ const metamaskDeepLink = (): string => {
   return `https://link.metamask.io/dapp/${host}${pathname}${search}`;
 };
 
+// Social apps' in-app browsers (WKWebView/Android WebView) don't reliably
+// hand universal links off to the MetaMask app, so the deep link dead-ends
+// there. Detect the common ones so we can guide the user to a real browser
+// instead. https://github.com/MetaMask/metamask-mobile/issues/4025
+const inAppBrowserName = (): string | null => {
+  if (typeof navigator === 'undefined') return null;
+  const ua = navigator.userAgent || '';
+  if (/FBAN|FBAV|FB_IAB/.test(ua)) return 'Facebook';
+  if (/Instagram/.test(ua)) return 'Instagram';
+  if (/Twitter/.test(ua)) return 'X';
+  if (/Line\//.test(ua)) return 'LINE';
+  if (/MicroMessenger/.test(ua)) return 'WeChat';
+  if (/TikTok|musical_ly|BytedanceWebview/i.test(ua)) return 'TikTok';
+  if (/Telegram/i.test(ua)) return 'Telegram';
+  if (/Snapchat/.test(ua)) return 'Snapchat';
+  if (/LinkedInApp/.test(ua)) return 'LinkedIn';
+  return null;
+};
+
 interface MetaMaskButtonProps {
   label?: string;
   chainId?: string | number;
@@ -145,6 +164,16 @@ export default function MetaMaskButton({
       // page in the MetaMask app's in-app browser, where the button works.
       // (Inside that browser a provider IS present, so we never reach here.)
       if (isMobile()) {
+        // A social app's in-app browser can't hand off to MetaMask, and the
+        // deep link would dead-end there — guide the user to a real browser.
+        const webview = inAppBrowserName();
+        if (webview) {
+          setStatus({
+            kind: 'info',
+            message: `You're in ${webview}'s in-app browser, which can't open MetaMask. Open this page in your default browser (use the menu → "Open in browser"), then tap again.`,
+          });
+          return;
+        }
         window.location.href = metamaskDeepLink();
         return;
       }

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { getChainID, errorCode, isMobile, inAppBrowserName, WalletStatus } from '../walletUtils';
 
 declare global {
   interface Window {
@@ -21,21 +22,6 @@ const METAMASK_RDNS = 'io.metamask';
 const isImpersonator = (p: any): boolean =>
   Boolean(p?.isOkxWallet || p?.isOKExWallet || p?.isCoinbaseWallet || p?.isTrust || p?.isTrustWallet || p?.isBraveWallet);
 
-// MetaMask mobile nests the EIP-1193 error code under data.originalError.code
-// instead of exposing it at the top level (e.g. 4902 for an unknown chain), so
-// read both. See https://github.com/MetaMask/metamask-mobile/issues/3312
-const errorCode = (e: any): number | undefined => e?.code ?? e?.data?.originalError?.code;
-
-// A normal mobile browser can't expose a wallet extension, so there's no
-// injected provider to talk to. Detect mobile (incl. iPadOS, which reports a
-// desktop UA but is touch-capable) so we can hand off to the MetaMask app.
-const isMobile = (): boolean => {
-  if (typeof navigator === 'undefined') return false;
-  const ua = navigator.userAgent;
-  return /Android|iPhone|iPod/i.test(ua) || /iPad/.test(ua) ||
-    (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
-};
-
 // Deep link that reopens the current page inside the MetaMask mobile app's
 // in-app browser, where a provider IS injected. Format is link.metamask.io/dapp
 // followed by the URL without its scheme. See:
@@ -43,25 +29,6 @@ const isMobile = (): boolean => {
 const metamaskDeepLink = (): string => {
   const { host, pathname, search } = window.location;
   return `https://link.metamask.io/dapp/${host}${pathname}${search}`;
-};
-
-// Social apps' in-app browsers (WKWebView/Android WebView) don't reliably
-// hand universal links off to the MetaMask app, so the deep link dead-ends
-// there. Detect the common ones so we can guide the user to a real browser
-// instead. https://github.com/MetaMask/metamask-mobile/issues/4025
-const inAppBrowserName = (): string | null => {
-  if (typeof navigator === 'undefined') return null;
-  const ua = navigator.userAgent || '';
-  if (/FBAN|FBAV|FB_IAB/.test(ua)) return 'Facebook';
-  if (/Instagram/.test(ua)) return 'Instagram';
-  if (/Twitter/.test(ua)) return 'X';
-  if (/Line\//.test(ua)) return 'LINE';
-  if (/MicroMessenger/.test(ua)) return 'WeChat';
-  if (/TikTok|musical_ly|BytedanceWebview/i.test(ua)) return 'TikTok';
-  if (/Telegram/i.test(ua)) return 'Telegram';
-  if (/Snapchat/.test(ua)) return 'Snapchat';
-  if (/LinkedInApp/.test(ua)) return 'LinkedIn';
-  return null;
 };
 
 interface MetaMaskButtonProps {
@@ -86,7 +53,7 @@ export default function MetaMaskButton({
   blockExplorerUrls = ['https://chainscan-galileo.0g.ai/']
 }: MetaMaskButtonProps): JSX.Element {
   // Inline, screen-reader-announced feedback (replaces alert()/console.log).
-  const [status, setStatus] = useState<{ kind: 'success' | 'error' | 'info'; message: string } | null>(null);
+  const [status, setStatus] = useState<WalletStatus | null>(null);
   // Guards against double-clicks that would trigger MetaMask's -32002.
   const [busy, setBusy] = useState(false);
 
@@ -123,11 +90,6 @@ export default function MetaMaskButton({
     if (eth?.isMetaMask && !isImpersonator(eth)) return eth;
 
     return null;
-  };
-
-  const getChainID = (networkId: string | number): string => {
-    const numeric = typeof networkId === 'string' ? parseInt(networkId) : networkId;
-    return '0x' + Number(numeric).toString(16);
   };
 
   // Add the chain, then report the outcome. Used when a switch reveals the

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -16,11 +16,16 @@ interface EIP6963ProviderDetail {
 
 const METAMASK_RDNS = 'io.metamask';
 
-// Other wallets (OKX, etc.) frequently set isMetaMask = true to impersonate
-// MetaMask, so that flag alone can't be trusted — only fall back to it after
-// EIP-6963 discovery fails, and exclude known impersonators.
+// Other wallets (OKX, Brave, etc.) frequently set isMetaMask = true to
+// impersonate MetaMask, so that flag alone can't be trusted — only fall back
+// to it after EIP-6963 discovery fails, and exclude known impersonators.
 const isImpersonator = (p: any): boolean =>
-  Boolean(p?.isOkxWallet || p?.isOKExWallet || p?.isCoinbaseWallet || p?.isTrust || p?.isTrustWallet);
+  Boolean(p?.isOkxWallet || p?.isOKExWallet || p?.isCoinbaseWallet || p?.isTrust || p?.isTrustWallet || p?.isBraveWallet);
+
+// MetaMask mobile nests the EIP-1193 error code under data.originalError.code
+// instead of exposing it at the top level (e.g. 4902 for an unknown chain), so
+// read both. See https://github.com/MetaMask/metamask-mobile/issues/3312
+const errorCode = (e: any): number | undefined => e?.code ?? e?.data?.originalError?.code;
 
 // A normal mobile browser can't expose a wallet extension, so there's no
 // injected provider to talk to. Detect mobile (incl. iPadOS, which reports a
@@ -63,6 +68,10 @@ export default function MetaMaskButton({
   blockExplorerUrls = ['https://chainscan-galileo.0g.ai/']
 }: MetaMaskButtonProps): JSX.Element {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  // Inline, screen-reader-announced feedback (replaces alert()/console.log).
+  const [status, setStatus] = useState<{ kind: 'success' | 'error' | 'info'; message: string } | null>(null);
+  // Guards against double-clicks that would trigger MetaMask's -32002.
+  const [busy, setBusy] = useState(false);
 
   // Collect EIP-6963 provider announcements as they arrive.
   const providersRef = useRef<EIP6963ProviderDetail[]>([]);
@@ -104,7 +113,34 @@ export default function MetaMaskButton({
     return '0x' + Number(numeric).toString(16);
   };
 
+  // Add the chain, then report the outcome. Used when a switch reveals the
+  // chain isn't in the wallet yet.
+  const addChain = async (provider: any, desiredChainHex: string) => {
+    try {
+      await provider.request({
+        method: 'wallet_addEthereumChain',
+        params: [{
+          chainId: desiredChainHex,
+          chainName,
+          nativeCurrency: { name: tokenName, symbol: tokenSymbol, decimals: tokenDecimals },
+          rpcUrls,
+          blockExplorerUrls,
+        }],
+      });
+      setStatus({ kind: 'success', message: `${chainName} added to MetaMask.` });
+    } catch (addError: any) {
+      if (errorCode(addError) === 4001) {
+        setStatus({ kind: 'info', message: 'Request cancelled.' });
+      } else {
+        setStatus({ kind: 'error', message: `Could not add ${chainName}. Please try again.` });
+      }
+    }
+  };
+
   const addNetwork = async () => {
+    if (busy) return;
+    setStatus(null);
+
     const provider = resolveMetaMaskProvider();
     if (!provider) {
       // On mobile there's no extension to inject a provider, so reopen this
@@ -114,91 +150,66 @@ export default function MetaMaskButton({
         window.location.href = metamaskDeepLink();
         return;
       }
-      alert(
-        'MetaMask not found. If you have multiple wallet extensions installed (e.g. OKX, Coinbase), set MetaMask as your default or disable the others, then try again.'
-      );
+      setStatus({
+        kind: 'error',
+        message:
+          'MetaMask not found. If you have multiple wallet extensions (e.g. OKX, Coinbase), set MetaMask as your default or disable the others, then try again.',
+      });
       return;
     }
 
     const desiredChainHex = getChainID(inputChainId);
-
-    // For Galileo Testnet specifically, keep the legacy migration helper
-    if (String(inputChainId) === '16601') {
-      const changedToGalileo = await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: desiredChainHex }] }).catch(async () => {
-        const changedToOldGalileo = await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: getChainID('80087') }] }).catch(async () => {
-          const params = [{
-            chainId: desiredChainHex,
-            chainName,
-            nativeCurrency: {
-              name: tokenName,
-              symbol: tokenSymbol,
-              decimals: tokenDecimals
-            },
-            rpcUrls,
-            blockExplorerUrls
-          }];
-
-          await provider.request({
-            method: 'wallet_addEthereumChain',
-            params
-          }).catch((error: any) => {
-            console.log(error);
+    setBusy(true);
+    try {
+      // For Galileo Testnet specifically, keep the legacy migration helper.
+      // NOTE: no shipped page passes 16601, so this branch is currently dead
+      // (see audit finding #5 — pending a decision on the Newton modal).
+      if (String(inputChainId) === '16601') {
+        const changedToGalileo = await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: desiredChainHex }] }).catch(async () => {
+          const changedToOldGalileo = await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: getChainID('80087') }] }).catch(async () => {
+            await addChain(provider, desiredChainHex);
+            return true;
           });
+          if (changedToOldGalileo) return false;
+          setIsModalOpen(true);
           return true;
         });
-
-        if (changedToOldGalileo) {
-          return false;
+        if (changedToGalileo) return;
+        const currentChainId = await provider.request({ method: 'eth_chainId' });
+        if (currentChainId === desiredChainHex) {
+          setStatus({ kind: 'success', message: '0G Testnet added to MetaMask.' });
         }
-
-        setIsModalOpen(true);
-        return true;
-      });
-
-      if (changedToGalileo) {
-        return false;
-      }
-
-      const currentChainId = await provider.request({ method: 'eth_chainId' });
-      if (currentChainId === desiredChainHex) {
-        alert('0G Testnet added');
         return;
       }
-      return;
-    }
 
-    // Generic flow for other networks (e.g., Mainnet)
-    try {
-      await provider.request({
-        method: 'wallet_switchEthereumChain',
-        params: [{ chainId: desiredChainHex }]
-      });
-      return;
-    } catch (switchError: any) {
-      if (switchError && switchError.code === 4902) {
-        try {
-          await provider.request({
-            method: 'wallet_addEthereumChain',
-            params: [{
-              chainId: desiredChainHex,
-              chainName,
-              nativeCurrency: {
-                name: tokenName,
-                symbol: tokenSymbol,
-                decimals: tokenDecimals
-              },
-              rpcUrls,
-              blockExplorerUrls
-            }]
-          });
-          alert(`${chainName} added`);
+      // Generic flow: try to switch, and add the chain if it isn't there yet.
+      try {
+        await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: desiredChainHex }] });
+        // MetaMask mobile can resolve the switch WITHOUT switching for an
+        // unknown chain (returns null instead of throwing 4902), so verify the
+        // active chain and fall through to add if it didn't actually switch.
+        // https://github.com/MetaMask/metamask-mobile/issues/12502
+        const current = await provider.request({ method: 'eth_chainId' });
+        if (typeof current === 'string' && current.toLowerCase() === desiredChainHex.toLowerCase()) {
+          setStatus({ kind: 'success', message: `Switched to ${chainName}.` });
           return;
-        } catch (addError) {
-          console.log(addError);
         }
-      } else {
-        console.log(switchError);
+        await addChain(provider, desiredChainHex);
+      } catch (switchError: any) {
+        const code = errorCode(switchError);
+        if (code === 4001) {
+          setStatus({ kind: 'info', message: 'Request cancelled.' });
+          return;
+        }
+        if (code === -32002) {
+          setStatus({ kind: 'info', message: 'Check MetaMask — a request is already open.' });
+          return;
+        }
+        // 4902 (in any shape) or anything else → the chain isn't added yet.
+        await addChain(provider, desiredChainHex);
       }
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -206,13 +217,16 @@ export default function MetaMaskButton({
     <div style={{ margin: '20px 0' }}>
       <button
         onClick={addNetwork}
+        disabled={busy}
+        aria-busy={busy}
         style={{
           backgroundColor: '#E2761B',
           color: 'white',
           padding: '10px 20px',
           border: 'none',
           borderRadius: '5px',
-          cursor: 'pointer',
+          cursor: busy ? 'wait' : 'pointer',
+          opacity: busy ? 0.7 : 1,
           fontSize: '16px',
           fontWeight: 'bold',
           display: 'inline-flex',
@@ -224,11 +238,23 @@ export default function MetaMaskButton({
           alt="MetaMask Fox"
           style={{ height: '18px' }}
         />
-        {label}
+        {busy ? 'Check MetaMask…' : label}
       </button>
-      <RemoveNewtonModal 
-        isOpen={isModalOpen} 
-        onClose={() => setIsModalOpen(false)} 
+      {status && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            marginTop: '10px',
+            fontSize: '14px',
+            color: status.kind === 'error' ? '#b00020' : status.kind === 'success' ? '#1a7f37' : '#555',
+          }}>
+          {status.message}
+        </div>
+      )}
+      <RemoveNewtonModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
       />
     </div>
   );

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -52,7 +52,7 @@ export default function MetaMaskButton({
   tokenName = '0G',
   tokenDecimals = 18,
   rpcUrls = ['https://evmrpc-testnet.0g.ai'],
-  blockExplorerUrls = ['https://chainscan-galileo.0g.ai/']
+  blockExplorerUrls = ['https://chainscan-galileo.0g.ai']
 }: MetaMaskButtonProps): JSX.Element {
   // Inline, screen-reader-announced feedback (replaces alert()/console.log).
   const [status, setStatus] = useState<WalletStatus | null>(null);

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import RemoveNewtonModal from '../RemoveNewtonModal';
 
 declare global {
   interface Window {
@@ -67,7 +66,6 @@ export default function MetaMaskButton({
   rpcUrls = ['https://evmrpc-testnet.0g.ai'],
   blockExplorerUrls = ['https://chainscan-galileo.0g.ai/']
 }: MetaMaskButtonProps): JSX.Element {
-  const [isModalOpen, setIsModalOpen] = useState(false);
   // Inline, screen-reader-announced feedback (replaces alert()/console.log).
   const [status, setStatus] = useState<{ kind: 'success' | 'error' | 'info'; message: string } | null>(null);
   // Guards against double-clicks that would trigger MetaMask's -32002.
@@ -161,28 +159,7 @@ export default function MetaMaskButton({
     const desiredChainHex = getChainID(inputChainId);
     setBusy(true);
     try {
-      // For Galileo Testnet specifically, keep the legacy migration helper.
-      // NOTE: no shipped page passes 16601, so this branch is currently dead
-      // (see audit finding #5 — pending a decision on the Newton modal).
-      if (String(inputChainId) === '16601') {
-        const changedToGalileo = await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: desiredChainHex }] }).catch(async () => {
-          const changedToOldGalileo = await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: getChainID('80087') }] }).catch(async () => {
-            await addChain(provider, desiredChainHex);
-            return true;
-          });
-          if (changedToOldGalileo) return false;
-          setIsModalOpen(true);
-          return true;
-        });
-        if (changedToGalileo) return;
-        const currentChainId = await provider.request({ method: 'eth_chainId' });
-        if (currentChainId === desiredChainHex) {
-          setStatus({ kind: 'success', message: '0G Testnet added to MetaMask.' });
-        }
-        return;
-      }
-
-      // Generic flow: try to switch, and add the chain if it isn't there yet.
+      // Try to switch, and add the chain if it isn't there yet.
       try {
         await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: desiredChainHex }] });
         // MetaMask mobile can resolve the switch WITHOUT switching for an
@@ -252,10 +229,6 @@ export default function MetaMaskButton({
           {status.message}
         </div>
       )}
-      <RemoveNewtonModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-      />
     </div>
   );
 } 

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { getChainID, errorCode, isMobile, inAppBrowserName, WalletStatus } from '../walletUtils';
+import { getChainID, errorCode, isMobile, inAppBrowserName, consumeUrlFlag, WalletStatus } from '../walletUtils';
 
 declare global {
   interface Window {
@@ -24,11 +24,13 @@ const isImpersonator = (p: any): boolean =>
 
 // Deep link that reopens the current page inside the MetaMask mobile app's
 // in-app browser, where a provider IS injected. Format is link.metamask.io/dapp
-// followed by the URL without its scheme. See:
+// followed by the URL without its scheme. The `mmadd` flag tells the page to
+// auto-resume the add once it reloads in MetaMask's browser. See:
 // https://docs.metamask.io/sdk/guides/use-deeplinks/
 const metamaskDeepLink = (): string => {
-  const { host, pathname, search } = window.location;
-  return `https://link.metamask.io/dapp/${host}${pathname}${search}`;
+  const url = new URL(window.location.href);
+  url.searchParams.set('mmadd', '1');
+  return `https://link.metamask.io/dapp/${url.host}${url.pathname}${url.search}`;
 };
 
 interface MetaMaskButtonProps {
@@ -45,7 +47,7 @@ interface MetaMaskButtonProps {
 export default function MetaMaskButton({
   label = "Add 0G Testnet",
   chainId: inputChainId = '16602',
-  chainName = '0G-Testnet-Galileo',
+  chainName = '0G Galileo Testnet',
   tokenSymbol = '0G',
   tokenName = '0G',
   tokenDecimals = 18,
@@ -56,6 +58,7 @@ export default function MetaMaskButton({
   const [status, setStatus] = useState<WalletStatus | null>(null);
   // Guards against double-clicks that would trigger MetaMask's -32002.
   const [busy, setBusy] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   // Collect EIP-6963 provider announcements as they arrive.
   const providersRef = useRef<EIP6963ProviderDetail[]>([]);
@@ -181,9 +184,30 @@ export default function MetaMaskButton({
     }
   };
 
+  // If we just returned from the mobile deep link (now inside MetaMask's in-app
+  // browser), scroll to the button and auto-resume the add once the provider is
+  // available — MetaMask has no deep link that adds a network directly.
+  useEffect(() => {
+    if (!consumeUrlFlag('mmadd')) return;
+    let tries = 0;
+    const id = window.setInterval(() => {
+      tries += 1;
+      if (resolveMetaMaskProvider()) {
+        window.clearInterval(id);
+        buttonRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        void addNetwork();
+      } else if (tries >= 20) {
+        window.clearInterval(id);
+      }
+    }, 150);
+    return () => window.clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div style={{ margin: '20px 0' }}>
       <button
+        ref={buttonRef}
         onClick={addNetwork}
         disabled={busy}
         aria-busy={busy}

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import RemoveNewtonModal from '../RemoveNewtonModal';
 
 declare global {
@@ -6,6 +6,21 @@ declare global {
     ethereum?: any;
   }
 }
+
+// EIP-6963: wallets announce themselves with a stable rdns identifier instead
+// of racing to overwrite window.ethereum. MetaMask's is `io.metamask`.
+interface EIP6963ProviderDetail {
+  info: { uuid: string; name: string; icon: string; rdns: string };
+  provider: any;
+}
+
+const METAMASK_RDNS = 'io.metamask';
+
+// Other wallets (OKX, etc.) frequently set isMetaMask = true to impersonate
+// MetaMask, so that flag alone can't be trusted — only fall back to it after
+// EIP-6963 discovery fails, and exclude known impersonators.
+const isImpersonator = (p: any): boolean =>
+  Boolean(p?.isOkxWallet || p?.isOKExWallet || p?.isCoinbaseWallet || p?.isTrust || p?.isTrustWallet);
 
 interface MetaMaskButtonProps {
   label?: string;
@@ -30,14 +45,52 @@ export default function MetaMaskButton({
 }: MetaMaskButtonProps): JSX.Element {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  // Collect EIP-6963 provider announcements as they arrive.
+  const providersRef = useRef<EIP6963ProviderDetail[]>([]);
+  useEffect(() => {
+    const onAnnounce = (event: Event) => {
+      const detail = (event as CustomEvent<EIP6963ProviderDetail>).detail;
+      if (!detail?.info?.uuid) return;
+      if (!providersRef.current.some((p) => p.info.uuid === detail.info.uuid)) {
+        providersRef.current = [...providersRef.current, detail];
+      }
+    };
+    window.addEventListener('eip6963:announceProvider', onAnnounce);
+    window.dispatchEvent(new Event('eip6963:requestProvider'));
+    return () => window.removeEventListener('eip6963:announceProvider', onAnnounce);
+  }, []);
+
+  // Resolve the genuine MetaMask provider rather than trusting window.ethereum,
+  // which may be any injected wallet when several extensions are installed.
+  const resolveMetaMaskProvider = (): any | null => {
+    // 1. EIP-6963 — the only reliable signal (rdns can't be spoofed by the page).
+    const announced = providersRef.current.find((p) => p.info.rdns === METAMASK_RDNS);
+    if (announced) return announced.provider;
+
+    // 2. Legacy multi-provider array, excluding known impersonators.
+    const eth = window.ethereum;
+    if (Array.isArray(eth?.providers)) {
+      const mm = eth.providers.find((p: any) => p?.isMetaMask && !isImpersonator(p));
+      if (mm) return mm;
+    }
+
+    // 3. Single injected provider, only if it genuinely looks like MetaMask.
+    if (eth?.isMetaMask && !isImpersonator(eth)) return eth;
+
+    return null;
+  };
+
   const getChainID = (networkId: string | number): string => {
     const numeric = typeof networkId === 'string' ? parseInt(networkId) : networkId;
     return '0x' + Number(numeric).toString(16);
   };
 
   const addNetwork = async () => {
-    if (typeof window.ethereum === 'undefined') {
-      alert('MetaMask is not installed! Please install MetaMask first.');
+    const provider = resolveMetaMaskProvider();
+    if (!provider) {
+      alert(
+        'MetaMask not found. If you have multiple wallet extensions installed (e.g. OKX, Coinbase), set MetaMask as your default or disable the others, then try again.'
+      );
       return;
     }
 
@@ -45,8 +98,8 @@ export default function MetaMaskButton({
 
     // For Galileo Testnet specifically, keep the legacy migration helper
     if (String(inputChainId) === '16601') {
-      const changedToGalileo = await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: desiredChainHex }] }).catch(async () => {
-        const changedToOldGalileo = await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: getChainID('80087') }] }).catch(async () => {
+      const changedToGalileo = await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: desiredChainHex }] }).catch(async () => {
+        const changedToOldGalileo = await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: getChainID('80087') }] }).catch(async () => {
           const params = [{
             chainId: desiredChainHex,
             chainName,
@@ -58,8 +111,8 @@ export default function MetaMaskButton({
             rpcUrls,
             blockExplorerUrls
           }];
-  
-          await window.ethereum.request({
+
+          await provider.request({
             method: 'wallet_addEthereumChain',
             params
           }).catch((error: any) => {
@@ -80,7 +133,7 @@ export default function MetaMaskButton({
         return false;
       }
 
-      const currentChainId = await window.ethereum.request({ method: 'eth_chainId' });
+      const currentChainId = await provider.request({ method: 'eth_chainId' });
       if (currentChainId === desiredChainHex) {
         alert('0G Testnet added');
         return;
@@ -90,7 +143,7 @@ export default function MetaMaskButton({
 
     // Generic flow for other networks (e.g., Mainnet)
     try {
-      await window.ethereum.request({
+      await provider.request({
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: desiredChainHex }]
       });
@@ -98,7 +151,7 @@ export default function MetaMaskButton({
     } catch (switchError: any) {
       if (switchError && switchError.code === 4902) {
         try {
-          await window.ethereum.request({
+          await provider.request({
             method: 'wallet_addEthereumChain',
             params: [{
               chainId: desiredChainHex,

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -22,6 +22,25 @@ const METAMASK_RDNS = 'io.metamask';
 const isImpersonator = (p: any): boolean =>
   Boolean(p?.isOkxWallet || p?.isOKExWallet || p?.isCoinbaseWallet || p?.isTrust || p?.isTrustWallet);
 
+// A normal mobile browser can't expose a wallet extension, so there's no
+// injected provider to talk to. Detect mobile (incl. iPadOS, which reports a
+// desktop UA but is touch-capable) so we can hand off to the MetaMask app.
+const isMobile = (): boolean => {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  return /Android|iPhone|iPod/i.test(ua) || /iPad/.test(ua) ||
+    (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
+};
+
+// Deep link that reopens the current page inside the MetaMask mobile app's
+// in-app browser, where a provider IS injected. Format is link.metamask.io/dapp
+// followed by the URL without its scheme. See:
+// https://docs.metamask.io/sdk/guides/use-deeplinks/
+const metamaskDeepLink = (): string => {
+  const { host, pathname, search } = window.location;
+  return `https://link.metamask.io/dapp/${host}${pathname}${search}`;
+};
+
 interface MetaMaskButtonProps {
   label?: string;
   chainId?: string | number;
@@ -88,6 +107,13 @@ export default function MetaMaskButton({
   const addNetwork = async () => {
     const provider = resolveMetaMaskProvider();
     if (!provider) {
+      // On mobile there's no extension to inject a provider, so reopen this
+      // page in the MetaMask app's in-app browser, where the button works.
+      // (Inside that browser a provider IS present, so we never reach here.)
+      if (isMobile()) {
+        window.location.href = metamaskDeepLink();
+        return;
+      }
       alert(
         'MetaMask not found. If you have multiple wallet extensions installed (e.g. OKX, Coinbase), set MetaMask as your default or disable the others, then try again.'
       );

--- a/src/components/OKXButton/index.tsx
+++ b/src/components/OKXButton/index.tsx
@@ -37,7 +37,7 @@ export default function OKXButton({
   tokenName = '0G',
   tokenDecimals = 18,
   rpcUrls = ['https://evmrpc-testnet.0g.ai'],
-  blockExplorerUrls = ['https://chainscan-galileo.0g.ai/']
+  blockExplorerUrls = ['https://chainscan-galileo.0g.ai']
 }: OKXButtonProps): JSX.Element {
   // Inline, screen-reader-announced feedback (replaces alert()/console.log).
   const [status, setStatus] = useState<WalletStatus | null>(null);

--- a/src/components/OKXButton/index.tsx
+++ b/src/components/OKXButton/index.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { getChainID, errorCode, isMobile, inAppBrowserName, WalletStatus } from '../walletUtils';
+import React, { useState, useEffect, useRef } from 'react';
+import { getChainID, errorCode, isMobile, inAppBrowserName, consumeUrlFlag, WalletStatus } from '../walletUtils';
 
 declare global {
   interface Window {
@@ -12,7 +12,9 @@ declare global {
 // is wrapped so OKX also offers its install page when the app isn't present.
 // https://web3.okx.com/build/docs/waas/app-universal-link
 const okxDeepLink = (): string => {
-  const inner = 'okx://wallet/dapp/url?dappUrl=' + encodeURIComponent(window.location.href);
+  const url = new URL(window.location.href);
+  url.searchParams.set('okxadd', '1'); // auto-resume the add once back in OKX's browser
+  const inner = 'okx://wallet/dapp/url?dappUrl=' + encodeURIComponent(url.toString());
   return 'https://web3.okx.com/download?deeplink=' + encodeURIComponent(inner);
 };
 
@@ -30,7 +32,7 @@ interface OKXButtonProps {
 export default function OKXButton({
   label = "Add 0G Testnet",
   chainId: inputChainId = '16602',
-  chainName = '0G-Testnet-Galileo',
+  chainName = '0G Galileo Testnet',
   tokenSymbol = '0G',
   tokenName = '0G',
   tokenDecimals = 18,
@@ -41,6 +43,7 @@ export default function OKXButton({
   const [status, setStatus] = useState<WalletStatus | null>(null);
   // Guards against double-clicks that would trigger the wallet's -32002.
   const [busy, setBusy] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   // Add the chain, then report the outcome. Used when a switch reveals the
   // chain isn't in the wallet yet.
@@ -124,9 +127,30 @@ export default function OKXButton({
     }
   };
 
+  // If we just returned from the mobile deep link (now inside OKX's in-app
+  // browser), scroll to the button and auto-resume the add once the wallet is
+  // available — OKX has no deep link that adds a network directly.
+  useEffect(() => {
+    if (!consumeUrlFlag('okxadd')) return;
+    let tries = 0;
+    const id = window.setInterval(() => {
+      tries += 1;
+      if (typeof window.okxwallet !== 'undefined') {
+        window.clearInterval(id);
+        buttonRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        void addNetwork();
+      } else if (tries >= 20) {
+        window.clearInterval(id);
+      }
+    }, 150);
+    return () => window.clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div style={{ margin: '20px 0' }}>
       <button
+        ref={buttonRef}
         onClick={addNetwork}
         disabled={busy}
         aria-busy={busy}

--- a/src/components/OKXButton/index.tsx
+++ b/src/components/OKXButton/index.tsx
@@ -1,10 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { getChainID, errorCode, isMobile, inAppBrowserName, WalletStatus } from '../walletUtils';
 
 declare global {
   interface Window {
     okxwallet?: any;
   }
 }
+
+// OKX's official universal link: reopen the current page in the OKX app's
+// in-app browser (which injects window.okxwallet). The inner okx:// deep link
+// is wrapped so OKX also offers its install page when the app isn't present.
+// https://web3.okx.com/build/docs/waas/app-universal-link
+const okxDeepLink = (): string => {
+  const inner = 'okx://wallet/dapp/url?dappUrl=' + encodeURIComponent(window.location.href);
+  return 'https://web3.okx.com/download?deeplink=' + encodeURIComponent(inner);
+};
 
 interface OKXButtonProps {
   label?: string;
@@ -27,52 +37,90 @@ export default function OKXButton({
   rpcUrls = ['https://evmrpc-testnet.0g.ai'],
   blockExplorerUrls = ['https://chainscan-galileo.0g.ai/']
 }: OKXButtonProps): JSX.Element {
-  const getChainID = (networkId: string | number): string => {
-    const numeric = typeof networkId === 'string' ? parseInt(networkId) : networkId;
-    return '0x' + Number(numeric).toString(16);
+  // Inline, screen-reader-announced feedback (replaces alert()/console.log).
+  const [status, setStatus] = useState<WalletStatus | null>(null);
+  // Guards against double-clicks that would trigger the wallet's -32002.
+  const [busy, setBusy] = useState(false);
+
+  // Add the chain, then report the outcome. Used when a switch reveals the
+  // chain isn't in the wallet yet.
+  const addChain = async (desiredChainHex: string) => {
+    try {
+      await window.okxwallet.request({
+        method: 'wallet_addEthereumChain',
+        params: [{
+          chainId: desiredChainHex,
+          chainName,
+          nativeCurrency: { name: tokenName, symbol: tokenSymbol, decimals: tokenDecimals },
+          rpcUrls,
+          blockExplorerUrls,
+        }],
+      });
+      setStatus({ kind: 'success', message: `${chainName} added to OKX Wallet.` });
+    } catch (addError: any) {
+      if (errorCode(addError) === 4001) {
+        setStatus({ kind: 'info', message: 'Request cancelled.' });
+      } else {
+        setStatus({ kind: 'error', message: `Could not add ${chainName}. Please try again.` });
+      }
+    }
   };
 
   const addNetwork = async () => {
+    if (busy) return;
+    setStatus(null);
+
     if (typeof window.okxwallet === 'undefined') {
-      alert('OKX Wallet is not installed! Please install OKX Wallet first.');
-      return;
-    }
-
-    const chainId = getChainID(inputChainId);
-    const currentChainId = await window.okxwallet.request({ method: 'eth_chainId' });
-    if (currentChainId === chainId) {
-      alert(`Already connected to ${chainName}!`);
-      return;
-    }
-
-    try {
-      await window.okxwallet.request({
-        method: 'wallet_switchEthereumChain',
-        params: [{ chainId }]
-      });
-    } catch (switchError: any) {
-      if (switchError.code === 4902) {
-        try {
-          await window.okxwallet.request({
-            method: 'wallet_addEthereumChain',
-            params: [{
-              chainId,
-              chainName,
-              nativeCurrency: {
-                name: tokenName,
-                symbol: tokenSymbol,
-                decimals: tokenDecimals
-              },
-              rpcUrls,
-              blockExplorerUrls
-            }]
+      // On mobile there's no extension; hand off to the OKX app, whose in-app
+      // browser injects window.okxwallet. A social app's in-app browser can't
+      // do that handoff, so guide the user to a real browser instead.
+      if (isMobile()) {
+        const webview = inAppBrowserName();
+        if (webview) {
+          setStatus({
+            kind: 'info',
+            message: `You're in ${webview}'s in-app browser, which can't open OKX Wallet. Open this page in your default browser (use the menu → "Open in browser"), then tap again.`,
           });
-        } catch (addError) {
-          console.log(addError);
+          return;
         }
-      } else {
-        console.log(switchError);
+        window.location.href = okxDeepLink();
+        return;
       }
+      setStatus({
+        kind: 'error',
+        message: 'OKX Wallet not found. Install the OKX Wallet extension, then try again.',
+      });
+      return;
+    }
+
+    const desiredChainHex = getChainID(inputChainId);
+    setBusy(true);
+    try {
+      try {
+        await window.okxwallet.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: desiredChainHex }] });
+        // Verify the active chain, since mobile can resolve a switch without
+        // actually switching for an unknown chain (returns null, not 4902).
+        const current = await window.okxwallet.request({ method: 'eth_chainId' });
+        if (typeof current === 'string' && current.toLowerCase() === desiredChainHex.toLowerCase()) {
+          setStatus({ kind: 'success', message: `Switched to ${chainName}.` });
+          return;
+        }
+        await addChain(desiredChainHex);
+      } catch (switchError: any) {
+        const code = errorCode(switchError);
+        if (code === 4001) {
+          setStatus({ kind: 'info', message: 'Request cancelled.' });
+          return;
+        }
+        if (code === -32002) {
+          setStatus({ kind: 'info', message: 'Check OKX Wallet — a request is already open.' });
+          return;
+        }
+        // 4902 (in any shape) or anything else → the chain isn't added yet.
+        await addChain(desiredChainHex);
+      }
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -80,13 +128,16 @@ export default function OKXButton({
     <div style={{ margin: '20px 0' }}>
       <button
         onClick={addNetwork}
+        disabled={busy}
+        aria-busy={busy}
         style={{
           backgroundColor: '#101D42', // OKX brand color
           color: 'white',
           padding: '10px 20px',
           border: 'none',
           borderRadius: '5px',
-          cursor: 'pointer',
+          cursor: busy ? 'wait' : 'pointer',
+          opacity: busy ? 0.7 : 1,
           fontSize: '16px',
           fontWeight: 'bold',
           display: 'inline-flex',
@@ -98,8 +149,20 @@ export default function OKXButton({
           alt="OKX Wallet"
           style={{ height: '18px' }}
         />
-        {label}
+        {busy ? 'Check OKX Wallet…' : label}
       </button>
+      {status && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            marginTop: '10px',
+            fontSize: '14px',
+            color: status.kind === 'error' ? '#b00020' : status.kind === 'success' ? '#1a7f37' : '#555',
+          }}>
+          {status.message}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/RemoveNewtonModal/index.tsx
+++ b/src/components/RemoveNewtonModal/index.tsx
@@ -37,7 +37,7 @@ const RemoveNewtonModal: React.FC<RemoveNewtonModalProps> = ({ isOpen, onClose }
         <div style={styles.modalBody}>
           <p>
             The old Testnet versions are no longer active. 
-            Please remove it from your MetaMask network list before adding the current <strong>0G-Galileo-Testnet</strong> to avoid potential conflicts.
+            Please remove it from your MetaMask network list before adding the current <strong>0G Galileo Testnet</strong> to avoid potential conflicts.
           </p>
           <ol>
             <li>Open MetaMask and click the network dropdown menu at the top.</li>

--- a/src/components/walletUtils.ts
+++ b/src/components/walletUtils.ts
@@ -24,6 +24,20 @@ export const isMobile = (): boolean => {
     (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
 };
 
+// Returns true if `param` is present in the URL, and strips it (via
+// replaceState) so a reload doesn't re-fire. Used to auto-resume an add-network
+// after the mobile deep link reopens the page inside the wallet's in-app
+// browser — MetaMask/OKX have no deep link that adds a chain directly, so the
+// button re-invokes the flow itself on arrival.
+export const consumeUrlFlag = (param: string): boolean => {
+  if (typeof window === 'undefined') return false;
+  const url = new URL(window.location.href);
+  if (url.searchParams.get(param) === null) return false;
+  url.searchParams.delete(param);
+  window.history.replaceState(null, '', url.toString());
+  return true;
+};
+
 // Social apps' in-app browsers (WKWebView/Android WebView) don't reliably hand
 // universal links off to a wallet app, so a deep link dead-ends there. Detect
 // the common ones so callers can guide the user to a real browser instead.

--- a/src/components/walletUtils.ts
+++ b/src/components/walletUtils.ts
@@ -1,0 +1,44 @@
+// Shared helpers for the wallet "Add network" buttons (MetaMaskButton, OKXButton).
+// Keep wallet-agnostic logic here so the two buttons can't drift apart.
+
+export type WalletStatus = { kind: 'success' | 'error' | 'info'; message: string };
+
+// Chain id as the 0x-prefixed hex string the wallet RPC methods expect.
+export const getChainID = (networkId: string | number): string => {
+  const numeric = typeof networkId === 'string' ? parseInt(networkId) : networkId;
+  return '0x' + Number(numeric).toString(16);
+};
+
+// MetaMask/OKX mobile nest the EIP-1193 error code under data.originalError.code
+// instead of exposing it at the top level (e.g. 4902 for an unknown chain), so
+// read both. https://github.com/MetaMask/metamask-mobile/issues/3312
+export const errorCode = (e: any): number | undefined => e?.code ?? e?.data?.originalError?.code;
+
+// A normal mobile browser can't expose a wallet extension, so there's no
+// injected provider to talk to. Detect mobile (incl. iPadOS, which reports a
+// desktop UA but is touch-capable) so callers can hand off to the wallet app.
+export const isMobile = (): boolean => {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  return /Android|iPhone|iPod/i.test(ua) || /iPad/.test(ua) ||
+    (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
+};
+
+// Social apps' in-app browsers (WKWebView/Android WebView) don't reliably hand
+// universal links off to a wallet app, so a deep link dead-ends there. Detect
+// the common ones so callers can guide the user to a real browser instead.
+// https://github.com/MetaMask/metamask-mobile/issues/4025
+export const inAppBrowserName = (): string | null => {
+  if (typeof navigator === 'undefined') return null;
+  const ua = navigator.userAgent || '';
+  if (/FBAN|FBAV|FB_IAB/.test(ua)) return 'Facebook';
+  if (/Instagram/.test(ua)) return 'Instagram';
+  if (/Twitter/.test(ua)) return 'X';
+  if (/Line\//.test(ua)) return 'LINE';
+  if (/MicroMessenger/.test(ua)) return 'WeChat';
+  if (/TikTok|musical_ly|BytedanceWebview/i.test(ua)) return 'TikTok';
+  if (/Telegram/i.test(ua)) return 'Telegram';
+  if (/Snapchat/.test(ua)) return 'Snapchat';
+  if (/LinkedInApp/.test(ua)) return 'LinkedIn';
+  return null;
+};


### PR DESCRIPTION
## Summary

Overhauls the "Add 0G network" wallet buttons (`MetaMaskButton`, `OKXButton`) on the testnet and mainnet docs pages. Started as a fix for an "Add to MetaMask" failure in Chrome, then — via a multi-agent edge-case audit and research into MetaMask's own recommendations — closed the full set of robustness gaps. Both buttons stay **deliberately dependency-free** (no wagmi/viem/SDK), which is the right weight for a docs site; the fixes bring them to "Chainlist-quality" while matching MetaMask's documented guidance.

## What was broken

- **The reported bug:** clicking "Add to MetaMask" with OKX (or another wallet) installed threw `Unexpected error` from OKX's injected `evmAsk.js` — the button called `window.ethereum`, whichever wallet had hijacked it (many set `isMetaMask = true` to impersonate).
- **Mobile:** the button did nothing in a normal mobile browser (no extension → no injected provider).
- **Error handling** matched none of MetaMask's three documented codes robustly (`4902`/`4001`/`-32002`), and `4902` is nested/absent on MetaMask mobile — so first-time add silently failed there.

## Changes

**Desktop multi-wallet** — resolve the real MetaMask via **EIP-6963** (`rdns: io.metamask`) instead of trusting `window.ethereum`; legacy `providers[]`/`isMetaMask` are fallbacks with known impersonators (OKX, Brave, Coinbase, Trust) excluded.

**Mobile** — when no provider is injected:
- Normal mobile browser → deep link into the wallet's in-app browser (`link.metamask.io/dapp/<url>` for MetaMask; OKX's `okx://wallet/dapp/url` universal link for OKX).
- Detected social in-app webview (Instagram, X, Facebook, TikTok, Telegram, …) → guidance to open in the default browser, since universal-link handoff is unreliable there (an OS limitation no web page — or the SDK — fully solves).

**RPC robustness** — switch-then-add-on-`4902` per MetaMask's official guidance, reading the **nested mobile error shape** and re-checking `eth_chainId` after a switch (mobile can resolve without switching). Handle `4001` (rejected) and `-32002` (pending) explicitly.

**UX / a11y** — replace `alert()`/`console.log` with an inline `aria-live` status region; add an in-flight guard (`disabled`/`aria-busy`) so double-clicks can't trigger `-32002`.

**Cleanup** — remove the dead `16601` migration branch (no shipped page passes it; `RemoveNewtonModal` is retained for the testnet page's "Need help?" link). Extract shared logic into `walletUtils.ts` so both buttons share one source of truth (notably the webview list).

**Docs** — `AGENTS.md` gains a "Wallet buttons" section capturing these invariants and the deliberate no-dependency stance.

## How the audit informed this

A multi-agent edge-case audit surfaced 10 confirmed issues; research into MetaMask's docs independently produced the same `4902`/`4001`/`-32002` checklist and confirmed the mobile-`4902` bug ([metamask-mobile#3312](https://github.com/MetaMask/metamask-mobile/issues/3312), [#12502](https://github.com/MetaMask/metamask-mobile/issues/12502)) and the social-webview limitation ([#4025](https://github.com/MetaMask/metamask-mobile/issues/4025)). The SDK was evaluated and intentionally not adopted — it's a dApp-sized dependency for one button, and it doesn't solve the webview case either.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `pnpm build` passes (custom plugins included)
- [x] cspell passes on `AGENTS.md`
- [ ] CI green on this PR
- [ ] **Manual (needs real devices — can't be exercised in CI):**
  - [ ] Desktop with MetaMask **and** OKX installed → button adds via MetaMask, not OKX
  - [ ] Desktop MetaMask: add when chain absent, switch when present, reject (4001), double-click (-32002)
  - [ ] Mobile Safari/Chrome (no extension) → deep-links into the MetaMask / OKX app and adds the network
  - [ ] From inside a social app's in-app browser → shows "open in default browser" guidance
  - [ ] Repeat the add/switch/reject checks for the OKX button

## Notes
- Webview detection is UA-heuristic (Telegram et al. don't always set a distinctive UA); an undetected webview falls through to the deep link — no regression vs. today.
- Branch was rebased onto `main` (Node 24 / pnpm 11 / Docusaurus 3.10 toolchain).
