### PR TITLE
Migrate provider routing to X-0G-Provider-* headers

### DIFF
--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -354,7 +354,7 @@ response = client.chat.completions.create(
 )
 ```
 
-**Router also supports**: image generation via `POST /v1/images/generations` (OpenAI-compatible, sync) or `POST /v1/async/images/generations` + `GET /v1/async/jobs/{jobId}?provider_address=...` (recommended for production) — both paths must pass `"response_format": "b64_json"` today; URL responses will be added later. Also `/v1/audio/transcriptions`, provider routing (`provider.sort`: `latency` / `price`, or `provider.address` to pin), `GET /v1/models` (no auth), `GET /v1/account/balance`, `GET /v1/account/usage/{stats,history}`.
+**Router also supports**: image generation via `POST /v1/images/generations` (OpenAI-compatible, sync) or `POST /v1/async/images/generations` + `GET /v1/async/jobs/{jobId}?provider_address=...` (recommended for production) — both paths must pass `"response_format": "b64_json"` today; URL responses will be added later. Also `/v1/audio/transcriptions`, provider routing via `X-0G-Provider-*` request headers (`X-0G-Provider-Sort: latency`/`price`, or `X-0G-Provider-Address: 0x…` to pin), `GET /v1/models` (no auth), `GET /v1/account/balance`, `GET /v1/account/usage/{stats,history}`.
 
 **Quick Start — Direct (SDK)**:
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/audio.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/audio.md
@@ -70,13 +70,27 @@ print(result.text)
 
 ## 0G Router Extensions
 
-Because this endpoint uses `multipart/form-data` instead of a JSON body, the only Router extension that can be passed today is `verify_tee`, as a **query parameter**:
+Because this endpoint uses `multipart/form-data` instead of a JSON body, Router extensions are passed out-of-band — as a query parameter for `verify_tee`, and as `X-0G-Provider-*` request headers for provider routing.
+
+**TEE verification** — pass `verify_tee` as a query parameter:
 
 ```
 ?verify_tee=true
 ```
 
-See [Verifiable Execution](./verifiable-execution) for what `tee_verified` means in the response. Provider routing fields (`provider.address`, `provider.sort`) are not currently parsed on multipart endpoints — use the default round-robin or pin via [Provider Routing](../routing) on the JSON-body endpoints.
+See [Verifiable Execution](./verifiable-execution) for what `tee_verified` means in the response.
+
+**Provider routing** — pass `X-0G-Provider-*` headers, the same surface as JSON endpoints:
+
+```bash
+curl https://router-api.0g.ai/v1/audio/transcriptions \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -H "X-0G-Provider-Sort: latency" \
+  -F "file=@recording.mp3" \
+  -F "model=openai/whisper-large-v3"
+```
+
+See [Provider Routing](../routing) for the full header reference.
 
 ## Related
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/chat-completions.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/chat-completions.md
@@ -37,7 +37,7 @@ Optional top-level fields. Stripped before the request is forwarded to the provi
 
 | Field        | Type    | Description                                                                          |
 | ------------ | ------- | ------------------------------------------------------------------------------------ |
-| `provider`   | object  | Control provider routing — see [Routing](../routing)                                 |
+| `provider`   | object  | **Deprecated** — prefer `X-0G-Provider-*` request headers. See [Routing](../routing) |
 | `verify_tee` | boolean | Ask the Router to synchronously verify the provider's TEE signature — see [Verifiable Execution](./verifiable-execution) |
 
 ## Streaming

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/image-generation.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/image-generation.md
@@ -150,7 +150,7 @@ The same optional top-level fields as chat completions, stripped before forwardi
 
 | Field        | Type    | Description                                                                          |
 | ------------ | ------- | ------------------------------------------------------------------------------------ |
-| `provider`   | object  | Control provider routing — see [Routing](../routing)                                 |
+| `provider`   | object  | **Deprecated** — prefer `X-0G-Provider-*` request headers. See [Routing](../routing) |
 | `verify_tee` | boolean | Ask the Router to synchronously verify the provider's TEE signature — see [Verifiable Execution](./verifiable-execution) |
 
 ## Billing

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/verifiable-execution.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/verifiable-execution.md
@@ -139,4 +139,4 @@ All four steps pass → end-to-end cryptographic proof, no trust in the Router r
 
 - [**Principles: Verifiable Execution**](../principles#4-verifiable-execution) — the "why" behind this feature
 - [**Chat Completions**](./chat-completions#response-shape) — structure of the `x_0g_trace` block
-- [**Provider Routing**](../routing) — pin to a specific attested provider with `provider.address`
+- [**Provider Routing**](../routing) — pin to a specific attested provider with `X-0G-Provider-Address`

--- a/docs/developer-hub/building-on-0g/compute-network/router/models.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/models.md
@@ -52,7 +52,7 @@ If you send a `tools` field to a model that doesn't support it, the Router retur
 curl "https://router-api.0g.ai/v1/providers?model=zai-org/GLM-5-FP8"
 ```
 
-Returns every TEE-acknowledged provider serving that model, with on-chain address, observed latency, and TEE attestation info. Use these addresses with the [`provider.address` field](./routing) if you want deterministic routing.
+Returns every TEE-acknowledged provider serving that model, with on-chain address, observed latency, and TEE attestation info. Use these addresses with the [`X-0G-Provider-Address` header](./routing) if you want deterministic routing.
 
 Query parameters:
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -122,7 +122,7 @@ When both surfaces are present and set the same field, the header wins.
 
 ## Header Reference
 
-HTTP headers are case-insensitive per RFC 7230 — `X-0G-Provider-Address` and `x-0g-provider-address` are equivalent. Values are case-insensitive too unless noted.
+HTTP header names are case-insensitive per RFC 7230 — `X-0G-Provider-Address` and `x-0g-provider-address` are equivalent.
 
 | Header                          | Values                              | Description                                                                                                  |
 | ------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -128,7 +128,7 @@ HTTP header names are case-insensitive per RFC 7230 — `X-0G-Provider-Address` 
 | ------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `X-0G-Provider-Address`         | on-chain address (`0x…`)            | Pin the request to a specific provider. Implies `Allow-Fallbacks: false` unless overridden.                  |
 | `X-0G-Provider-Sort`            | `latency` \| `price`                | Sort strategy when no address is pinned. Ignored if `X-0G-Provider-Address` is set.                          |
-| `X-0G-Provider-Trust-Mode`      | `verified` \| `private`             | Restrict provider selection to a trust tier. The legacy `standard` tier is no longer accepted.               |
+| `X-0G-Provider-Trust-Mode`      | `verified` \| `private`             | Restrict provider selection to a trust tier.                                                                  |
 | `X-0G-Provider-Allow-Fallbacks` | `true` \| `false`                   | Allow cross-provider retry on failure. Lenient: anything other than `true`/`false` is treated as unset and defers to the default. |
 
 Defaults: `Allow-Fallbacks` is `true` normally, and `false` when `X-0G-Provider-Address` is set.

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -34,7 +34,7 @@ The Router accepts routing preferences from two surfaces. In priority order:
 Headers and body are merged field-by-field; when the same field is set on both, the header wins. Multipart endpoints (`/v1/audio/transcriptions`, `/v1/images/edits`, `/v1/async/images/edits`) have **no body routing surface** — headers are the only way to control routing there.
 
 :::caution The JSON body `provider` object is deprecated
-New code should use `X-0G-Provider-*` headers. The body surface still works today, but a future release will emit a `Deprecation: true` response header on body-source requests and eventually stop parsing the field. Headers are the only routing surface that works uniformly across JSON, multipart, and async endpoints.
+New code should use `X-0G-Provider-*` headers. The body surface still works today for back-compat but will be phased out in a future release. Headers are the only routing surface that works uniformly across JSON, multipart, and async endpoints.
 :::
 
 ## Routing Strategies

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -128,10 +128,21 @@ HTTP header names are case-insensitive per RFC 7230 — `X-0G-Provider-Address` 
 | ------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `X-0G-Provider-Address`         | on-chain address (`0x…`)            | Pin the request to a specific provider. Implies `Allow-Fallbacks: false` unless overridden.                  |
 | `X-0G-Provider-Sort`            | `latency` \| `price`                | Sort strategy when no address is pinned. Ignored if `X-0G-Provider-Address` is set.                          |
-| `X-0G-Provider-Trust-Mode`      | `verified` \| `private`             | Restrict provider selection to a trust tier.                                                                  |
+| `X-0G-Provider-Trust-Mode`      | `verified` \| `private`             | Restrict provider selection to a trust tier — see [Trust modes](#trust-modes).                                |
 | `X-0G-Provider-Allow-Fallbacks` | `true` \| `false`                   | Allow cross-provider retry on failure. Lenient: anything other than `true`/`false` is treated as unset and defers to the default. |
 
 Defaults: `Allow-Fallbacks` is `true` normally, and `false` when `X-0G-Provider-Address` is set.
+
+### Trust modes
+
+`X-0G-Provider-Trust-Mode` restricts selection by the provider's [verification mode](../inference#verification-modes):
+
+| Value      | Routes to                      | Guarantee                                                                                          |
+| ---------- | ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `verified` | TeeML **and** TeeTLS providers | Verifiable execution — the response provably came from the real model.                              |
+| `private`  | TeeML providers only           | Verifiability **and** privacy — the model itself runs inside the TEE, so prompts never leave the enclave. |
+
+`verified` is a floor, not an exact match: TeeML (`private`-tier) providers also satisfy a `verified` request, since running the model inside the TEE gives you everything TeeTLS does and more. Values other than `verified`/`private` are rejected with `400 invalid_trust_mode`. Omit the header for no trust-tier restriction (the default).
 
 ## Discovering Provider Addresses
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -126,7 +126,7 @@ HTTP header names are case-insensitive per RFC 7230 — `X-0G-Provider-Address` 
 
 | Header                          | Values                              | Description                                                                                                  |
 | ------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `X-0G-Provider-Address`         | on-chain address (`0x…`)            | Pin the request to a specific provider. Implies `Allow-Fallbacks: false` unless overridden — see below.       |
+| `X-0G-Provider-Address`         | on-chain address (`0x…`)            | Pin the request to a specific provider. Implies `Allow-Fallbacks: false` unless overridden.                  |
 | `X-0G-Provider-Sort`            | `latency` \| `price`                | Sort strategy when no address is pinned. Ignored if `X-0G-Provider-Address` is set.                          |
 | `X-0G-Provider-Trust-Mode`      | `verified` \| `private`             | Restrict provider selection to a trust tier. The legacy `standard` tier is no longer accepted.               |
 | `X-0G-Provider-Allow-Fallbacks` | `true` \| `false`                   | Allow cross-provider retry on failure. Lenient: anything other than `true`/`false` is treated as unset and defers to the default. |

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -2,7 +2,7 @@
 id: routing
 title: Provider Routing
 sidebar_position: 5
-description: "Control which provider serves your request — by latency, price, or specific on-chain address."
+description: "Control which provider serves your request — by latency, price, or specific on-chain address — via X-0G-Provider-* request headers."
 ---
 
 import Tabs from '@theme/Tabs';
@@ -10,11 +10,11 @@ import TabItem from '@theme/TabItem';
 
 # Provider Routing
 
-By default, the Router distributes requests across healthy providers using round-robin with automatic failover. The `provider` field lets you override this when you need specific behavior.
+By default, the Router distributes requests across healthy providers using round-robin with automatic failover. `X-0G-Provider-*` request headers let you override this when you need specific behavior.
 
 ## Default Behavior
 
-If you send no `provider` field, the Router:
+If you send no routing headers, the Router:
 
 1. Picks a healthy provider for the requested model
 2. Retries on the next healthy provider if the first returns an error
@@ -22,10 +22,88 @@ If you send no `provider` field, the Router:
 
 This is the recommended path for most applications.
 
+## Routing surfaces
+
+The Router accepts routing preferences from two surfaces. In priority order:
+
+| Priority | Surface | Endpoints | Status |
+| -------- | ------- | --------- | ------ |
+| 1 | `X-0G-Provider-*` request headers | All inference endpoints (JSON, multipart, async) | **Canonical** |
+| 2 | JSON body `provider: {…}` object | JSON endpoints only (`/v1/chat/completions`, `/v1/messages`, `/v1/images/generations`, `/v1/async/images/generations`) | Deprecated — kept for back-compat |
+
+Headers and body are merged field-by-field; when the same field is set on both, the header wins. Multipart endpoints (`/v1/audio/transcriptions`, `/v1/images/edits`, `/v1/async/images/edits`) have **no body routing surface** — headers are the only way to control routing there.
+
+:::caution The JSON body `provider` object is deprecated
+New code should use `X-0G-Provider-*` headers. The body surface still works today, but a future release will emit a `Deprecation: true` response header on body-source requests and eventually stop parsing the field. Headers are the only routing surface that works uniformly across JSON, multipart, and async endpoints.
+:::
+
 ## Routing Strategies
 
 <Tabs>
 <TabItem value="latency" label="Lowest Latency" default>
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -H "X-0G-Provider-Sort: latency" \
+  -d '{
+    "model": "zai-org/GLM-5-FP8",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+Routes to the provider with the lowest recently-observed latency for this model.
+
+</TabItem>
+<TabItem value="price" label="Lowest Price">
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -H "X-0G-Provider-Sort: price" \
+  -d '{
+    "model": "zai-org/GLM-5-FP8",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+Routes to the cheapest provider currently serving this model.
+
+</TabItem>
+<TabItem value="address" label="Pin a Specific Provider">
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -H "X-0G-Provider-Address: 0xd9966e..." \
+  -d '{
+    "model": "zai-org/GLM-5-FP8",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+Routes directly to a specific provider by on-chain address. **Fallback is disabled by default when pinning** — if the pinned provider fails, the request fails. Add `X-0G-Provider-Allow-Fallbacks: true` to re-enable cross-provider retry (see [Pinned address + fallbacks](#pinned-address--fallbacks) below).
+
+</TabItem>
+<TabItem value="multipart" label="Multipart (audio / image edit)">
+
+Multipart endpoints accept the same headers — this is the only routing surface available there.
+
+```bash
+curl https://router-api.0g.ai/v1/audio/transcriptions \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -H "X-0G-Provider-Sort: latency" \
+  -F "file=@recording.mp3" \
+  -F "model=openai/whisper-large-v3"
+```
+
+</TabItem>
+<TabItem value="json-body" label="JSON body (deprecated)">
+
+The legacy JSON body surface still works on JSON endpoints. New code should prefer headers.
 
 ```json
 {
@@ -37,48 +115,38 @@ This is the recommended path for most applications.
 }
 ```
 
-Routes to the provider with the lowest recently-observed latency for this model.
-
-</TabItem>
-<TabItem value="price" label="Lowest Price">
-
-```json
-{
-  "model": "zai-org/GLM-5-FP8",
-  "messages": [{"role": "user", "content": "Hello"}],
-  "provider": {
-    "sort": "price"
-  }
-}
-```
-
-Routes to the cheapest provider currently serving this model.
-
-</TabItem>
-<TabItem value="address" label="Pin a Specific Provider">
-
-```json
-{
-  "model": "zai-org/GLM-5-FP8",
-  "messages": [{"role": "user", "content": "Hello"}],
-  "provider": {
-    "address": "0xd9966e..."
-  }
-}
-```
-
-Routes directly to a specific provider by on-chain address. **Fallback is disabled by default when pinning** — if the pinned provider fails, the request fails. Set `allow_fallbacks: true` to re-enable cross-provider retry.
+When both surfaces are present and set the same field, the header wins.
 
 </TabItem>
 </Tabs>
 
-## `provider` Field Reference
+## Header Reference
 
-| Field              | Type    | Description                                                                                     |
-| ------------------ | ------- | ----------------------------------------------------------------------------------------------- |
-| `sort`             | string  | `"latency"` or `"price"`. Ignored if `address` is set.                                          |
-| `address`          | string  | Provider's on-chain address for direct routing.                                                 |
-| `allow_fallbacks`  | boolean | Allow retrying other providers on failure. Default: `true` normally, `false` when `address` is set. |
+HTTP headers are case-insensitive per RFC 7230 — `X-0G-Provider-Address` and `x-0g-provider-address` are equivalent. Values are case-insensitive too unless noted.
+
+| Header                          | Values                              | Description                                                                                                  |
+| ------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `X-0G-Provider-Address`         | on-chain address (`0x…`)            | Pin the request to a specific provider. Implies `Allow-Fallbacks: false` unless overridden — see below.       |
+| `X-0G-Provider-Sort`            | `latency` \| `price`                | Sort strategy when no address is pinned. Ignored if `X-0G-Provider-Address` is set.                          |
+| `X-0G-Provider-Trust-Mode`      | `verified` \| `private`             | Restrict provider selection to a trust tier. The legacy `standard` tier is no longer accepted.               |
+| `X-0G-Provider-Allow-Fallbacks` | `true` \| `false`                   | Allow cross-provider retry on failure. Lenient: anything other than `true`/`false` is treated as unset and defers to the default. |
+
+Defaults: `Allow-Fallbacks` is `true` normally, and `false` when `X-0G-Provider-Address` is set.
+
+## Pinned address + fallbacks
+
+Pinning a provider via `X-0G-Provider-Address` re-derives `Allow-Fallbacks=false` unconditionally — **even if a JSON body's `provider.allow_fallbacks: true` is also present**. The Router cannot distinguish "body explicitly set true" from "body absent (default true)", so it treats a header-pinned address as the strict request.
+
+To pin an address **and** allow fallback, set both headers explicitly:
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "X-0G-Provider-Address: 0xd9966e..." \
+  -H "X-0G-Provider-Allow-Fallbacks: true" \
+  -d '{ "model": "zai-org/GLM-5-FP8", "messages": [{"role":"user","content":"Hello"}] }'
+```
 
 ## Discovering Provider Addresses
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -85,7 +85,7 @@ curl https://router-api.0g.ai/v1/chat/completions \
   }'
 ```
 
-Routes directly to a specific provider by on-chain address. **Fallback is disabled by default when pinning** — if the pinned provider fails, the request fails. Add `X-0G-Provider-Allow-Fallbacks: true` to re-enable cross-provider retry (see [Pinned address + fallbacks](#pinned-address--fallbacks) below).
+Routes directly to a specific provider by on-chain address. **Fallback is disabled by default when pinning** — if the pinned provider fails, the request fails. Add `X-0G-Provider-Allow-Fallbacks: true` to re-enable cross-provider retry.
 
 </TabItem>
 <TabItem value="multipart" label="Multipart (audio / image edit)">
@@ -132,21 +132,6 @@ HTTP header names are case-insensitive per RFC 7230 — `X-0G-Provider-Address` 
 | `X-0G-Provider-Allow-Fallbacks` | `true` \| `false`                   | Allow cross-provider retry on failure. Lenient: anything other than `true`/`false` is treated as unset and defers to the default. |
 
 Defaults: `Allow-Fallbacks` is `true` normally, and `false` when `X-0G-Provider-Address` is set.
-
-## Pinned address + fallbacks
-
-Pinning a provider via `X-0G-Provider-Address` re-derives `Allow-Fallbacks=false` unconditionally — **even if a JSON body's `provider.allow_fallbacks: true` is also present**. The Router cannot distinguish "body explicitly set true" from "body absent (default true)", so it treats a header-pinned address as the strict request.
-
-To pin an address **and** allow fallback, set both headers explicitly:
-
-```bash
-curl https://router-api.0g.ai/v1/chat/completions \
-  -H "Authorization: Bearer sk-YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -H "X-0G-Provider-Address: 0xd9966e..." \
-  -H "X-0G-Provider-Allow-Fallbacks: true" \
-  -d '{ "model": "zai-org/GLM-5-FP8", "messages": [{"role":"user","content":"Hello"}] }'
-```
 
 ## Discovering Provider Addresses
 


### PR DESCRIPTION
## Description

Migrates the provider routing API from JSON body fields to HTTP request headers (`X-0G-Provider-*`), establishing headers as the canonical routing surface across all endpoint types (JSON, multipart, and async).

### Key Changes

- **New canonical routing surface**: Introduces `X-0G-Provider-Address`, `X-0G-Provider-Sort`, `X-0G-Provider-Trust-Mode`, and `X-0G-Provider-Allow-Fallbacks` headers
- **Unified multipart support**: Multipart endpoints (`/v1/audio/transcriptions`, `/v1/images/edits`) now support provider routing via headers (previously unsupported)
- **Deprecation path**: JSON body `provider` object is now deprecated but remains functional for backward compatibility; headers take precedence when both are present
- **Dual-surface merging**: Headers and body fields are merged field-by-field, with headers winning on conflicts
- **Updated documentation**: 
  - Routing guide now shows header-based examples as primary, with body examples marked deprecated
  - Audio transcription docs updated to show header-based routing
  - Chat completions and image generation docs mark `provider` field as deprecated
  - Added comprehensive header reference table with defaults and behavior notes

### Backward Compatibility

The JSON body `provider` field continues to work on JSON endpoints. A future release will emit deprecation warnings and eventually remove body-based routing. Headers are the only routing surface that works uniformly across all endpoint types.

## Related Issue

N/A

## Type of Change

- [x] Documentation update

## Testing

- [x] Tested locally with `yarn start`
- [x] Build passes with `yarn build`
- [x] Links work correctly

## Checklist

- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

https://claude.ai/code/session_015DeaLgR7vXQ4KYuVgmq415