### PR TITLE
fix: serve security headers in production via vercel.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ keywords: [keyword1, keyword2]
 ### Custom plugins (`src/plugins/`)
 
 - `markdown-endpoint-plugin.js` — copies raw `.md`/`.mdx` files into the build output so `docs.0g.ai/concepts/compute.md` returns raw markdown. Used by LLM tooling. Also installs dev-server middleware so the same routes work under `pnpm start`.
-- `security-headers-plugin.js` — sets CSP, X-Frame-Options, HSTS, etc. on the dev server. Production headers are set in `static/_headers` (Vercel) and `vercel.json`.
+- `security-headers-plugin.js` — sets CSP, X-Frame-Options, HSTS, etc. on the dev server. Production headers are set in `vercel.json`'s `headers` array **only** — Vercel does not read `_headers` files (that's a Netlify/Cloudflare Pages convention; a stale `static/_headers` used to sit here shipping nothing, and was removed). When a new page or component loads a third-party resource, the CSP in `vercel.json` (and the dev plugin, for parity) must be extended or the resource will be silently blocked in production.
 - `docusaurus-plugin-llms` — generates `llms.txt` and `llms-full.txt` at the site root from the docs corpus.
 
 ### Wallet buttons (`src/components/`)

--- a/src/plugins/security-headers-plugin.js
+++ b/src/plugins/security-headers-plugin.js
@@ -1,8 +1,9 @@
 /**
  * Security Headers Plugin for Docusaurus
- * 
- * This plugin adds security headers to protect against clickjacking and other vulnerabilities.
- * It works by adding middleware to the development server and generating a _headers file for production.
+ *
+ * Adds security headers to the DEV SERVER ONLY, via middleware. Production
+ * headers are served by Vercel from vercel.json's `headers` array — keep the
+ * CSP here in sync with that one so `pnpm start` mirrors production policy.
  */
 
 module.exports = function securityHeadersPlugin(context, options) {
@@ -24,7 +25,7 @@ module.exports = function securityHeadersPlugin(context, options) {
         // Content Security Policy
         res.setHeader(
           'Content-Security-Policy',
-          "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://www.googletagmanager.com https://www.clarity.ms https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; img-src 'self' data: https://www.google-analytics.com https://www.clarity.ms; font-src 'self' https://cdnjs.cloudflare.com; frame-ancestors 'none'; frame-src 'self' https://challenges.cloudflare.com; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://www.clarity.ms https://build.0g.ai;"
+          "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.googletagmanager.com https://www.clarity.ms https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://fonts.googleapis.com; img-src 'self' data: https://*.google-analytics.com https://*.googletagmanager.com https://*.clarity.ms https://github.com; font-src 'self' data: https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.clarity.ms https://c.bing.com https://build.0g.ai; frame-src 'self' https://challenges.cloudflare.com https://www.youtube.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
         );
         
         // HTTPS enforcement

--- a/static/_headers
+++ b/static/_headers
@@ -1,7 +1,0 @@
-/*
-  X-Frame-Options: DENY
-  X-Content-Type-Options: nosniff
-  Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://www.googletagmanager.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://fonts.googleapis.com; img-src 'self' data: https://www.google-analytics.com; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; frame-ancestors 'none'; frame-src 'self' https://challenges.cloudflare.com; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://*.supabase.co https://cdn.lottielab.com https://build.0g.ai; script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com https://cdn.jsdelivr.net https://challenges.cloudflare.com;
-  Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Permissions-Policy: geolocation=(), microphone=(), camera=()

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,19 @@
       "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
     },
     {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.googletagmanager.com https://www.clarity.ms https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://fonts.googleapis.com; img-src 'self' data: https://*.google-analytics.com https://*.googletagmanager.com https://*.clarity.ms https://github.com; font-src 'self' data: https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.clarity.ms https://c.bing.com https://build.0g.ai; frame-src 'self' https://challenges.cloudflare.com https://www.youtube.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
+        }
+      ]
+    },
+    {
       "source": "/llms.txt",
       "headers": [
         { "key": "Content-Type", "value": "text/plain; charset=utf-8" },


### PR DESCRIPTION
## Description

**Production currently serves no CSP or security headers at all** (verify: `curl -sI https://docs.0g.ai` — only Vercel's own HSTS comes back). The repo *thought* they were set in `static/_headers`, but `_headers` files are a Netlify/Cloudflare Pages convention that **Vercel ignores** — the file has been shipping nothing since the move to Vercel.

This PR moves the headers to the surface Vercel actually reads: the `headers` array in `vercel.json`.

### Changes

- **`vercel.json`** — new global (`/(.*)`) rule serving `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, and a freshly **audited** `Content-Security-Policy` (see below). HSTS is left to Vercel (already served, `max-age=63072000`).
- **`static/_headers`** — deleted (dead weight; misleading).
- **`AGENTS.md` + plugin doc comment** — corrected: both claimed `_headers` was the production surface / that the dev plugin "generates a _headers file". Neither was true.

### Why not just copy the old CSP?

The `_headers` policy was never enforced, and auditing it against what prod actually loads showed it was stale in both directions:

- **Would have broken prod**: no `clarity.ms` in `script-src` (Clarity runs on prod), no `cdn.jsdelivr.net` in `font-src` (KaTeX webfonts), no `fonts.googleapis.com`/`fonts.gstatic.com` for the Geist Mono/Inter `@import`, no `frame-src` for the YouTube embeds in docs.
- **Allowed things the site no longer uses**: `*.supabase.co`, `cdn.lottielab.com` (the Lottie animation loads same-origin from `/animations/`).

The new policy is derived from: `docusaurus.config.ts` stylesheets (Font Awesome via cdnjs, KaTeX via jsDelivr), `src/css/custom.css` font imports, gtag + Clarity (GA4/Clarity official CSP guidance, incl. `c.bing.com` for Clarity), YouTube doc embeds, GitHub-hosted images in docs, and the Ask AI widget origins from #321 (`build.0g.ai` connect + `challenges.cloudflare.com` script/frame — harmless if this lands first).

### Verification

- `vercel.json` is valid JSON; the CI link-check's `jq` serve-config step handles the new rule (no `has` key, survives the filter).
- `pnpm build` passes; `_headers` no longer in build output.
- The new rule is **not host-scoped**, so the preview deployment for this PR serves the full CSP — the preview URL can be browsed to confirm zero console CSP violations on KaTeX pages, YouTube-embed pages, and fonts. (gtag/Clarity are prod-gated and can't fire on previews; their directives follow vendor guidance.)

### Note

Conflicts trivially with #321 on `static/_headers` (modified there, deleted here) — whichever lands second needs a one-line rebase; I'll handle it.

## Type of Change

- [x] Bug fix

## Testing

- [x] `pnpm build` passes
- [x] `vercel.json` validates
- [ ] Preview deployment console check (after Vercel builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)