### PR TITLE
Add price ceiling headers for provider routing

### DIFF
--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -354,7 +354,7 @@ response = client.chat.completions.create(
 )
 ```
 
-**Router also supports**: image generation via `POST /v1/images/generations` (OpenAI-compatible, sync) or `POST /v1/async/images/generations` + `GET /v1/async/jobs/{jobId}?provider_address=...` (recommended for production) — both paths must pass `"response_format": "b64_json"` today; URL responses will be added later. Also `/v1/audio/transcriptions`, provider routing via `X-0G-Provider-*` request headers (`X-0G-Provider-Sort: latency`/`price`, or `X-0G-Provider-Address: 0x…` to pin), `GET /v1/models` (no auth), `GET /v1/account/balance`, `GET /v1/account/usage/{stats,history}`.
+**Router also supports**: image generation via `POST /v1/images/generations` (OpenAI-compatible, sync) or `POST /v1/async/images/generations` + `GET /v1/async/jobs/{jobId}?provider_address=...` (recommended for production) — both paths must pass `"response_format": "b64_json"` today; URL responses will be added later. Also `/v1/audio/transcriptions`, provider routing via `X-0G-Provider-*` request headers (`X-0G-Provider-Sort: latency`/`price`, `X-0G-Provider-Address: 0x…` to pin, or `X-0G-Provider-Max-Price-Usd-Prompt`/`-Completion`/`-Image` to cap per-request price — header-only, malformed values return `400`), `GET /v1/models` (no auth), `GET /v1/account/balance`, `GET /v1/account/usage/{stats,history}`.
 
 **Quick Start — Direct (SDK)**:
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/errors.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/errors.md
@@ -39,7 +39,7 @@ Errors follow a consistent OpenAI-compatible shape. The response also includes `
 
 | `type`                  | `code` (examples)                                            | When it happens                                      |
 | ----------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
-| `invalid_request_error` | `invalid_body`, `missing_authorization`, `invalid_api_key`, `api_key_revoked`, `invalid_provider_header`, `invalid_max_price_usd`, `no_provider_within_max_price`, `pinned_provider_exceeds_max_price` | 400, 401 — request or auth is wrong (incl. malformed `X-0G-Provider-*` headers and price-ceiling conflicts) |
+| `invalid_request_error` | `invalid_body`, `missing_authorization`, `invalid_api_key`, `api_key_revoked`, `invalid_provider_header`, `invalid_max_price_usd`, `no_provider_within_max_price`, `pinned_provider_exceeds_max_price` | 400, 401 — request, auth, or routing headers are wrong (incl. malformed `X-0G-Provider-*` values and unsatisfiable price ceilings) |
 | `payment_error`         | `insufficient_balance`                                       | 402 — not enough 0G deposited                        |
 | `permission_error`      | `access_denied`                                              | 403 — the key is not allowed to perform this action  |
 | `not_found_error`       | `api_key_not_found`                                          | 404 — resource doesn't exist                         |

--- a/docs/developer-hub/building-on-0g/compute-network/router/errors.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/errors.md
@@ -39,7 +39,7 @@ Errors follow a consistent OpenAI-compatible shape. The response also includes `
 
 | `type`                  | `code` (examples)                                            | When it happens                                      |
 | ----------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
-| `invalid_request_error` | `invalid_body`, `missing_authorization`, `invalid_api_key`, `api_key_revoked` | 400, 401 — request or auth is wrong |
+| `invalid_request_error` | `invalid_body`, `missing_authorization`, `invalid_api_key`, `api_key_revoked`, `invalid_provider_header`, `invalid_max_price_usd`, `no_provider_within_max_price`, `pinned_provider_exceeds_max_price` | 400, 401 — request or auth is wrong (incl. malformed `X-0G-Provider-*` headers and price-ceiling conflicts) |
 | `payment_error`         | `insufficient_balance`                                       | 402 — not enough 0G deposited                        |
 | `permission_error`      | `access_denied`                                              | 403 — the key is not allowed to perform this action  |
 | `not_found_error`       | `api_key_not_found`                                          | 404 — resource doesn't exist                         |

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -198,13 +198,6 @@ The ceiling is **service-type aware**. Setting `Image` on a chat call (or `Promp
 STT models are billed per second of audio, which has no equivalent in the current USD pricing schema (`prompt` / `completion` / `image` only). Reusing the `Prompt` header for STT would be a footgun — the same `1.0` would mean "$1 per 1M tokens" on chat and "$1 per second" on audio — so `/v1/audio/transcriptions` enforces no ceiling for now.
 :::
 
-### Semantics
-
-- **No USD pricing metadata means excluded.** A provider whose pricing data lacks the dimension being filtered is dropped — a hard cap can't be honoured for an unknown price. The same applies if the advertised price is `NaN`, `Inf`, or negative.
-- **Pinning + a ceiling can conflict.** When `X-0G-Provider-Address` is set together with any `Max-Price-Usd-*` header, the pinned provider is checked against the ceiling directly. If it's over, the request fails with `400 pinned_provider_exceeds_max_price` rather than silently honouring the pin.
-- **Empty pool is a `400`, not a `503`.** If auto-select finds no provider clearing the ceiling, you get `400 no_provider_within_max_price` — a structural failure of your constraints, distinct from `503 no_available_provider` (a transient lack of healthy providers). See [Errors](./errors).
-- **Header-only.** This ceiling has no JSON body equivalent. Setting `provider.max_price_usd` in the request body is silently ignored — the headers are the only path that applies it.
-
 ## Discovering Provider Addresses
 
 List the providers serving a model with `GET /v1/providers?model_id=…` — see [Models](./models#listing-providers-for-a-model).

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -198,6 +198,11 @@ The ceiling is **service-type aware**. Setting `Image` on a chat call (or `Promp
 STT models are billed per second of audio, which has no equivalent in the current USD pricing schema (`prompt` / `completion` / `image` only). Reusing the `Prompt` header for STT would be a footgun — the same `1.0` would mean "$1 per 1M tokens" on chat and "$1 per second" on audio — so `/v1/audio/transcriptions` enforces no ceiling for now.
 :::
 
+Two failure modes are worth calling out:
+
+- **No provider qualifies.** If the ceiling filters out every candidate, the request fails with `400 no_provider_within_max_price`, not `503` — the pool is empty structurally, not transiently, so retrying without raising the ceiling won't help.
+- **Pinning + ceiling.** If `X-0G-Provider-Address` pins a provider above the ceiling, the request fails with `400 pinned_provider_exceeds_max_price` — the pin isn't silently overridden.
+
 ## Discovering Provider Addresses
 
 List the providers serving a model with `GET /v1/providers?model_id=…` — see [Models](./models#listing-providers-for-a-model).

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -72,6 +72,23 @@ curl https://router-api.0g.ai/v1/chat/completions \
 Routes to the cheapest provider currently serving this model.
 
 </TabItem>
+<TabItem value="max-price" label="Cap Price">
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -H "X-0G-Provider-Max-Price-Usd-Prompt: 1.0" \
+  -H "X-0G-Provider-Max-Price-Usd-Completion: 5.0" \
+  -d '{
+    "model": "zai-org/GLM-5-FP8",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+Drops every provider above the ceiling **before** sorting and failover, so even a fallback during an outage can't route you to a more expensive provider. See [Capping price per request](#capping-price-per-request).
+
+</TabItem>
 <TabItem value="address" label="Pin a Specific Provider">
 
 ```bash
@@ -127,11 +144,16 @@ HTTP header names are case-insensitive per RFC 7230 — `X-0G-Provider-Address` 
 | Header                          | Values                              | Description                                                                                                  |
 | ------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `X-0G-Provider-Address`         | on-chain address (`0x…`)            | Pin the request to a specific provider. Implies `Allow-Fallbacks: false` unless overridden.                  |
-| `X-0G-Provider-Sort`            | `latency` \| `price`                | Sort strategy when no address is pinned. Ignored if `X-0G-Provider-Address` is set.                          |
+| `X-0G-Provider-Sort`            | `latency` \| `price`                | Sort strategy when no address is pinned. Ignored if `X-0G-Provider-Address` is set. Must be exactly `latency` or `price` — any other non-empty value is rejected with `400 invalid_provider_header`. |
 | `X-0G-Provider-Trust-Mode`      | `verified` \| `private`             | Restrict provider selection to a trust tier — see [Trust modes](#trust-modes).                                |
-| `X-0G-Provider-Allow-Fallbacks` | `true` \| `false`                   | Allow cross-provider retry on failure. Lenient: anything other than `true`/`false` is treated as unset and defers to the default. |
+| `X-0G-Provider-Allow-Fallbacks` | `true` \| `false`                   | Allow cross-provider retry on failure. Must be exactly `true` or `false` (case-insensitive) — `1`, `0`, `yes`, and other non-empty values are rejected with `400 invalid_provider_header`. |
+| `X-0G-Provider-Max-Price-Usd-Prompt`     | finite, non-negative decimal | Per-request ceiling on prompt token price, USD per 1M tokens. See [Capping price per request](#capping-price-per-request). |
+| `X-0G-Provider-Max-Price-Usd-Completion` | finite, non-negative decimal | Per-request ceiling on completion token price, USD per 1M tokens. See [Capping price per request](#capping-price-per-request). |
+| `X-0G-Provider-Max-Price-Usd-Image`      | finite, non-negative decimal | Per-request ceiling on image price, USD per generated image. See [Capping price per request](#capping-price-per-request). |
 
 Defaults: `Allow-Fallbacks` is `true` normally, and `false` when `X-0G-Provider-Address` is set.
+
+A header that is absent, or blank after trimming whitespace, is treated as unset and falls back to the default. Only a **present-but-malformed** value is rejected — a blank header meaning "I didn't set this" is never an error.
 
 ### Trust modes
 
@@ -143,6 +165,45 @@ Defaults: `Allow-Fallbacks` is `true` normally, and `false` when `X-0G-Provider-
 | `private`  | TeeML providers only           | Verifiability **and** privacy — the model itself runs inside the TEE, so prompts never leave the enclave. |
 
 `verified` is a floor, not an exact match: TeeML (`private`-tier) providers also satisfy a `verified` request, since running the model inside the TEE gives you everything TeeTLS does and more. Values other than `verified`/`private` are rejected with `400 invalid_trust_mode`. Omit the header for no trust-tier restriction (the default).
+
+## Capping price per request
+
+The `X-0G-Provider-Max-Price-Usd-*` headers set a **hard ceiling** on what you're willing to pay. Any provider above the ceiling on a relevant dimension is dropped from the candidate pool entirely — this is a filter, not a preference, and it runs **before** sorting and failover. A fallback during an outage can never silently route you to a provider you've priced out.
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -H "X-0G-Provider-Max-Price-Usd-Prompt: 1.0" \
+  -H "X-0G-Provider-Max-Price-Usd-Completion: 5.0" \
+  -d '{
+    "model": "zai-org/GLM-5-FP8",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+Send any subset — one header, two, or all three. Each value is a finite, non-negative decimal; `NaN`, `Inf`, negative, and non-numeric values are rejected with `400 invalid_max_price_usd`.
+
+### Which dimension applies to which endpoint
+
+The ceiling is **service-type aware**. Setting `Image` on a chat call (or `Prompt` / `Completion` on an image call) is silently inert, so a cross-endpoint SDK that always sends all three headers won't accidentally filter out every provider.
+
+| Service type            | Endpoints                                                    | Dimensions enforced     | Unit                   |
+| ----------------------- | ----------------------------------------------------------- | ----------------------- | ---------------------- |
+| Chat                    | `/v1/chat/completions`, `/v1/messages`                      | `Prompt`, `Completion`  | USD per 1M tokens      |
+| Image                   | `/v1/images/generations`, `/v1/images/edits`, `/v1/async/images/*` | `Image`          | USD per generated image |
+| Speech-to-text          | `/v1/audio/transcriptions`                                  | none yet — see below    | —                      |
+
+:::note Speech-to-text is not covered yet
+STT models are billed per second of audio, which has no equivalent in the current USD pricing schema (`prompt` / `completion` / `image` only). Reusing the `Prompt` header for STT would be a footgun — the same `1.0` would mean "$1 per 1M tokens" on chat and "$1 per second" on audio — so `/v1/audio/transcriptions` enforces no ceiling for now.
+:::
+
+### Semantics
+
+- **No USD pricing metadata means excluded.** A provider whose pricing data lacks the dimension being filtered is dropped — a hard cap can't be honoured for an unknown price. The same applies if the advertised price is `NaN`, `Inf`, or negative.
+- **Pinning + a ceiling can conflict.** When `X-0G-Provider-Address` is set together with any `Max-Price-Usd-*` header, the pinned provider is checked against the ceiling directly. If it's over, the request fails with `400 pinned_provider_exceeds_max_price` rather than silently honouring the pin.
+- **Empty pool is a `400`, not a `503`.** If auto-select finds no provider clearing the ceiling, you get `400 no_provider_within_max_price` — a structural failure of your constraints, distinct from `503 no_available_provider` (a transient lack of healthy providers). See [Errors](./errors).
+- **Header-only.** This ceiling has no JSON body equivalent. Setting `provider.max_price_usd` in the request body is silently ignored — the headers are the only path that applies it.
 
 ## Discovering Provider Addresses
 


### PR DESCRIPTION
## Description

Adds support for per-request price ceilings via three new HTTP headers: `X-0G-Provider-Max-Price-Usd-Prompt`, `X-0G-Provider-Max-Price-Usd-Completion`, and `X-0G-Provider-Max-Price-Usd-Image`. These headers allow users to set hard limits on what they're willing to pay, filtering out providers above the ceiling before sorting and failover logic.

### Key changes:

- **New routing headers**: Three `X-0G-Provider-Max-Price-Usd-*` headers for setting per-request price ceilings (USD per 1M tokens for prompt/completion, USD per image for image generation)
- **New "Cap Price" routing strategy**: Added as a tab in the routing documentation alongside existing latency/price strategies
- **Stricter header validation**: Updated `X-0G-Provider-Sort` and `X-0G-Provider-Allow-Fallbacks` to reject malformed values with `400 invalid_provider_header` instead of lenient fallback behavior
- **New error codes**: Added `invalid_provider_header`, `invalid_max_price_usd`, `no_provider_within_max_price`, and `pinned_provider_exceeds_max_price` to the errors documentation
- **Comprehensive documentation**: Added "Capping price per request" section explaining semantics, service-type awareness, and conflict resolution with pinned providers

### Behavior:

- Price ceilings are **filters**, not preferences — they run before sorting and failover
- Service-type aware: `Image` ceiling is ignored on chat endpoints, `Prompt`/`Completion` ignored on image endpoints
- Pinning + ceiling can conflict: if a pinned provider exceeds the ceiling, request fails with `400 pinned_provider_exceeds_max_price`
- Empty pool after filtering returns `400 no_provider_within_max_price` (structural failure) rather than `503` (transient unavailability)
- Header-only feature: no JSON body equivalent

## Related Issue

N/A

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Style/UI change

## Testing

N/A — documentation-only change describing new API feature.

## Checklist

- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Documentation is clear and complete

https://claude.ai/code/session_01WiHVaf49XBqCg2PtSphMPP