### PR TITLE
docs: remove BitMart from How to Get 0G (platform wind-down)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -571,7 +571,6 @@
     "agentic",
     "infts",
     "bithumb",
-    "bitmart",
     "cbbtc",
     "interport",
     "khalani",

--- a/docs/introduction/how-to-get-0g.md
+++ b/docs/introduction/how-to-get-0g.md
@@ -37,7 +37,6 @@ The most straightforward way to acquire $0G is through centralized exchanges. Af
 | **[LBank](https://www.lbank.com/trade/0g_usdt)** | 0G/USDT, 0G/USDC |
 | **[Upbit](https://upbit.com/exchange?code=CRIX.UPBIT.KRW-0G)** | 0G/KRW, 0G/BTC, 0G/USDT |
 | **[Kraken](https://www.kraken.com/prices/0g)** | 0G/USD, 0G/EUR |
-| **[BitMart](https://www.bitmart.com/trade/en-US?symbol=0G_USDT)** | 0G/USDT |
 | **[Bithumb](https://www.bithumb.com/react/trade/order/0G-KRW)** | 0G/KRW |
 
 ## Bridge to 0G Chain


### PR DESCRIPTION
## Why

BitMart announced an orderly wind-down of its entire trading platform (official notice, July 26, 2026):

- Jul 26, 2026 01:30 UTC — new registrations, all deposits and new spot orders suspended
- Aug 26, 2026 01:00 UTC — all trading services discontinued
- Jan 31, 2027 15:59 UTC — platform operations cease

Source: [official BitMart notice](https://bitmart.zendesk.com/hc/en-us/articles/53544595916059-Important-Notice-Regarding-the-Orderly-Cessation-of-BitMart-Operations), confirmed on their verified X account.

With deposits and new spot orders already suspended, BitMart is no longer a venue where users can acquire $0G.

## What changed

- Removed the BitMart row from the centralized exchanges table in `docs/introduction/how-to-get-0g.md`
- Removed the now-unused `bitmart` term from `.cspell.json`

get.0g.ai is being updated in the same pass, so both surfaces stay in sync. `llms.txt` / `llms-full.txt` regenerate automatically via the docusaurus plugin.
