### PR TITLE
docs(router): correct the standard tier description and align retention with the router source

### DIFF
--- a/docs/developer-hub/building-on-0g/compute-network/router/privacy.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/privacy.md
@@ -12,11 +12,11 @@ This page describes exactly what happens to your data on the 0G Compute Router (
 
 ## Zero data retention
 
-The Router operates with zero data retention on text and audio inference content; file and image workflows use bounded transient storage:
+The Router operates with zero data retention on inference content:
 
-- **Prompts and completions are processed in memory only** for the lifetime of the request: the Router handles them in memory to route and bill the request, and never writes them to storage. There is no conversation table, no prompt log, no response archive.
+- **Prompts and completions are processed in memory only** for the lifetime of the request: the Router handles them in memory to route and bill the request, and never writes them to storage. There is no conversation table and no response archive; billing records carry metadata only.
 - **0G does not train on your data.** Content that is never stored cannot be used for training.
-- **Uploaded files are transient.** Files sent to multipart endpoints (audio transcription, image edits) are auto-deleted within **60 minutes**. Image-generation inputs and outputs are held for at most **30 minutes** to serve the result, then deleted.
+- **Multipart inputs are not stored.** Audio and image inputs sent to multipart endpoints are passed through in memory for the lifetime of the request and never persisted. The Router does not store generated images: results are returned to the caller and not kept.
 
 ### What is retained
 
@@ -43,12 +43,12 @@ This is the `private` tier of [trust-mode routing](./routing.md#trust-modes):
 |------|-----------|-----------|
 | `private` | TeeML providers only | Sealed inference: prompts never leave the enclave |
 | `verified` | TeeML and TeeTLS providers | Verifiable execution: the response provably came from the real model |
-| `standard` | Any TEE-backed provider (any tier) | TEE-backed execution; upstream discloses no independent verifiability method |
+| `standard` | All providers, including third-party channels | Full model access. Non-verifiable: no attestation or signed proof to check |
 
-With TeeTLS, 0G's broker (itself running inside a TEE) relays your request over attested TLS and cannot read it in transit, but the upstream provider processes your prompt under its own data policy. With `standard`, the request still runs on a TEE-backed provider, but the upstream discloses no independent verifiability method. If your requirement is that no third party ever sees plaintext, use `private`.
+With TeeTLS, 0G's broker (itself running inside a TEE) relays your request over attested TLS and cannot read it in transit, but the upstream provider processes your prompt under its own data policy. `standard` places no restriction on the provider pool: it widens the catalog to third-party channels that are non-verifiable. The serving broker runs on TEE hardware with verification disabled and the upstream is not disclosed, so there is no attestation or signature to check on the response. Today the Claude and GPT-5.6 families are served on this tier; the live list is always the [models endpoint](#models-with-privacy-mode). If your requirement is that no third party ever sees plaintext, use `private`.
 
 :::note Model selection is not tier selection
-When a model has both TeeML and TeeTLS providers, the Router balances between them for performance unless a trust mode is set. To guarantee the enclave, set the tier explicitly using one of the methods below.
+A request that does not set a trust mode can be served by **any** provider of the model, including `standard` ones, and the model list displays each model according to its **highest-capability** provider. When a model has multiple providers, the Router balances between them for performance. To guarantee a verifiable channel, pin the tier explicitly using one of the methods below.
 :::
 
 For workloads that must not touch the Router at all, [Advanced mode](https://pc.0g.ai/sdk) connects your wallet directly to a provider: funding and inference happen entirely inside the decentralized network, with no intermediary in the path.

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -161,11 +161,11 @@ A header that is absent, or blank after trimming whitespace, is treated as unset
 
 | Value      | Routes to                      | Guarantee                                                                                          |
 | ---------- | ------------------------------ | --------------------------------------------------------------------------------------------------- |
-| `standard` | Any TEE-backed provider        | TEE-backed execution; the upstream discloses no independent verifiability method.                   |
+| `standard` | All providers, including third-party channels | Full model access. Non-verifiable: no attestation or signed proof to check.                        |
 | `verified` | TeeML **and** TeeTLS providers | Verifiable execution — the response provably came from the real model.                              |
 | `private`  | TeeML providers only           | Verifiability **and** privacy — the model itself runs inside the TEE, so prompts never leave the enclave. |
 
-Values other than `standard`/`verified`/`private` are rejected with `400 invalid_trust_mode`. Omit the header for no trust-tier restriction (the default).
+Values other than `standard`/`verified`/`private` are rejected with `400 invalid_trust_mode`. Omit the header for no trust-tier restriction (the default) — an unrestricted request can be served by any provider of the model, including `standard` ones.
 
 ## Capping price per request
 


### PR DESCRIPTION
Follow-up to #340, applying the corrections agreed with product and engineering (Slack `#devrel-ecosystem`, PR #340 thread, Jul 28 and Aug 12).

## Standard tier description (`privacy.md` + `routing.md`)

The tier table and prose described `standard` as "TEE-backed execution". Engineering ruling: the standard tier is **non-verifiable** — the serving broker runs on TEE hardware but verification is disabled and the upstream is not disclosed, so there is no attestation or signature to check on the response. The broker source is explicit: `0g-serving-broker/api/inference/const/const.go` calls a standard provider "a pure forwarder that performs NO TEE verification". Live `/v1/models` confirms it: the Claude and GPT-5.6 families are served standard-only with `tee_attested: null`.

Both tier tables and the surrounding prose now read: all providers including third-party channels, full model access, non-verifiable.

## Routing default note

Per product confirmation: a request that does not set a trust mode can be served by **any** provider of the model, including `standard` ones, and the model list displays each model according to its **highest-capability** provider. The pin-the-tier note in `privacy.md` now states this, and `routing.md` clarifies the default.

## Retention (`privacy.md`)

Applies the post-merge review on #340 (verified against the `0g-router` source):

- The 60-minute TTL belongs to `/v1/files` only, and the file feature is disabled in production and slated for removal — the TTL claim is dropped.
- The 30-minute image-generation figure has no basis in the Router (it described a third-party broker's async result window) — dropped.
- Multipart audio/image inputs are passed through in memory and never persisted; the Router does not store generated images.
- "no prompt log" tightened to storage-scoped claims: no conversation table, no response archive, metadata-only billing records.

No new claims are introduced; every line traces to the router/broker source or an explicit product-team confirmation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/353)
<!-- Reviewable:end -->
