### PR TITLE
docs(router): add a Claude Code configuration page

### DIFF
--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -366,7 +366,7 @@ response = client.chat.completions.create(
 )
 ```
 
-**Router also supports**: image generation via `POST /v1/images/generations` (OpenAI-compatible, sync) or `POST /v1/async/images/generations` + `GET /v1/async/jobs/{jobId}?provider_address=...` (recommended for production) — both paths must pass `"response_format": "b64_json"` today; URL responses will be added later. Also `/v1/audio/transcriptions`, provider routing via `X-0G-Provider-*` request headers (`X-0G-Provider-Sort: latency`/`price`, `X-0G-Provider-Address: 0x…` to pin, or `X-0G-Provider-Max-Price-Usd-Prompt`/`-Completion`/`-Image` to cap per-request price — header-only, malformed values return `400`), `GET /v1/models` (no auth), `GET /v1/account/balance`, `GET /v1/account/usage/{stats,history}`.
+**Router also supports**: image generation via `POST /v1/images/generations` (OpenAI-compatible, sync) or `POST /v1/async/images/generations` + `GET /v1/async/jobs/{jobId}?provider_address=...` (recommended for production) — both paths must pass `"response_format": "b64_json"` today; URL responses will be added later. Also `/v1/audio/transcriptions`, provider routing via `X-0G-Provider-*` request headers (`X-0G-Provider-Sort: latency`/`price`, `X-0G-Provider-Address: 0x…` to pin, or `X-0G-Provider-Max-Price-Usd-Prompt`/`-Completion`/`-Image` to cap per-request price — header-only, malformed values return `400`), `GET /v1/models` (no auth), `GET /v1/account/balance`, `GET /v1/account/usage/{stats,history}`. The Router also serves the **Anthropic Messages API** (`POST /v1/messages`): set `ANTHROPIC_BASE_URL=https://router-api.0g.ai` to point Anthropic SDKs or Claude Code at it; models listing `"anthropic"` in `supported_formats` on `GET /v1/models` support this format.
 
 **Quick Start — Direct (SDK)**:
 
@@ -416,6 +416,7 @@ client = OpenAI(
   - Quickstart: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/quickstart](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/quickstart)
   - Models: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/models](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/models)
   - Chat Completions: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/features/chat-completions](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/features/chat-completions)
+  - Claude Code (Anthropic API): [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/clients/claude-code](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/clients/claude-code)
   - Provider Routing: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/routing](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/routing)
   - Deposits & Billing: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/account/deposits](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/account/deposits)
   - Router vs Direct: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/comparison](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/comparison)

--- a/docs/developer-hub/building-on-0g/compute-network/router/clients/claude-code.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/clients/claude-code.md
@@ -1,0 +1,76 @@
+---
+id: claude-code
+title: Claude Code
+sidebar_position: 1
+description: "Configure Claude Code to run on the 0G Compute Router."
+---
+
+# Claude Code
+
+[Claude Code](https://code.claude.com/docs) reaches the Router over the Anthropic Messages
+API, so it needs configuration only — no plugin, no proxy.
+
+## Configure
+
+Create `~/.claude/settings.json` (Windows: `C:\Users\<username>\.claude\settings.json`)
+and replace `YOUR_API_KEY` with a Router [API key](../authentication):
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://router-api.0g.ai",
+    "ANTHROPIC_AUTH_TOKEN": "YOUR_API_KEY",
+    "ANTHROPIC_API_KEY": "",
+
+    "ANTHROPIC_MODEL": "glm-5.2",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL": "glm-5.2",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.2",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "0gm-1.0-35b-a3b",
+
+    "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "983616"
+  },
+  "modelOverrides": {
+    "claude-sonnet-5": "0gm-1.0-35b-a3b"
+  }
+}
+```
+
+Then run:
+
+```bash
+claude --permission-mode auto
+```
+
+## Private mode
+
+Both models above are TEE-backed (`"verifiability": "TeeML"`). To guarantee every Claude
+Code request runs inside an enclave, create the key with trust mode **Private** in
+Dashboard → API Keys — that key routes only to TeeML providers regardless of what the
+client sends. See [Privacy & ZDR](../privacy#enabling-privacy-mode).
+
+## Notes
+
+- **`modelOverrides`** sets the model behind auto mode's permission gate, which runs
+  before every non-read-only action. Use it rather than
+  `ANTHROPIC_DEFAULT_SONNET_MODEL`: that one replaces the slot, leaving Claude Code
+  unable to recognize the model, so it stops disabling reasoning and a yes/no check
+  turns into a full reasoning pass.
+- **`ANTHROPIC_DEFAULT_HAIKU_MODEL`** covers background work — session names for
+  `claude --resume`, status for commands like `/usage`.
+- **`CLAUDE_CODE_MAX_CONTEXT_TOKENS`** is the main model's real context window. Without
+  it Claude Code assumes 200 K and compacts at a fifth of `glm-5.2`'s 1 M.
+- **`--permission-mode auto`** is required per session, or set
+  `{"permissions": {"defaultMode": "auto"}}` in `~/.claude/settings.json`. With an API
+  key, sessions otherwise start in Manual mode.
+- Everything under `env` also works as shell exports; `modelOverrides` does not.
+
+## Models
+
+Claude Code needs a model that serves the Anthropic Messages API:
+
+```bash
+curl -s https://router-api.0g.ai/v1/models \
+  | jq -r '.data[] | select(.supported_formats | index("anthropic")) | .id'
+```
+
+Any of those work in any slot. See [Models](../models) for pricing and context windows.

--- a/docs/developer-hub/building-on-0g/compute-network/router/clients/claude-code.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/clients/claude-code.md
@@ -41,12 +41,12 @@ Then run:
 claude --permission-mode auto
 ```
 
-## Private mode
-
+:::tip Private mode
 Both models above are TEE-backed (`"verifiability": "TeeML"`). To guarantee every Claude
 Code request runs inside an enclave, create the key with trust mode **Private** in
 Dashboard → API Keys — that key routes only to TeeML providers regardless of what the
 client sends. See [Privacy & ZDR](../privacy#enabling-privacy-mode).
+:::
 
 ## Notes
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/quickstart.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/quickstart.md
@@ -92,4 +92,5 @@ That's it. You're talking to a decentralized TEE-backed provider through an Open
 
 - **[Chat Completions](./features/chat-completions)** — streaming, tool calling, system prompts
 - **[Provider Routing](./routing)** — route by latency, price, or specific provider
+- **[Claude Code](./clients/claude-code)** — point Claude Code at the Router, including auto mode's permission gate
 - **[Models](./models)** — browse the catalog with live pricing

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -122,6 +122,19 @@ const sidebars: SidebarsConfig = {
                             'developer-hub/building-on-0g/compute-network/router/features/verifiable-execution',
                           ],
                         },
+                        {
+                          type: 'category',
+                          label: 'Clients & Dev Tools',
+                          link: {
+                            type: 'generated-index',
+                            title: 'Clients & Dev Tools',
+                            description:
+                              'Point an existing client or coding tool at the Router — configuration only, no SDK changes.',
+                          },
+                          items: [
+                            'developer-hub/building-on-0g/compute-network/router/clients/claude-code',
+                          ],
+                        },
                         'developer-hub/building-on-0g/compute-network/router/routing',
                         'developer-hub/building-on-0g/compute-network/router/authentication',
                         'developer-hub/building-on-0g/compute-network/router/privacy',


### PR DESCRIPTION
Claude Code reaches the Router over `/v1/messages`, so using it is a configuration change rather than an integration — but nothing in the docs said how. This adds **Router → Claude Code**, placed after Models in the sidebar and linked from the Quickstart's next steps.

The thing worth documenting is that Claude Code drives several models at once, and getting the secondary slots wrong is what makes the tool feel slow rather than what makes it fail. The page leads with the whole settings file, then explains each key.

Three points that cost real debugging time to find:

- **Auto mode runs a permission gate before every non-read-only action**, on the `sonnet` slot. Redirect it with `modelOverrides`, not `ANTHROPIC_DEFAULT_SONNET_MODEL` — replacing the slot leaves Claude Code unable to recognize the model, so it stops sending the flag that turns reasoning off and a yes/no gate becomes a full reasoning pass. Measured on the Router: ~1–2 s per gate call with `modelOverrides`, two to three times that without.
- **Without `CLAUDE_CODE_MAX_CONTEXT_TOKENS`**, Claude Code doesn't recognize `glm-5.2` and assumes a 200 K window, so auto-compact starts summarizing at a fifth of the 1 M the model actually has.
- **Claude Code needs `anthropic` in a model's `supported_formats`.** A model without it is rejected on `/v1/messages` and can't fill any slot, so the page shows how to list the models that qualify.

It also explains why the gate can look like it never runs — read-only actions and edits inside the working directory are approved locally with no model call — so a quiet session isn't misread as a broken configuration.

## Verification

- `npm run build` passes with 0 MDX errors and no broken links; `claude-code.html` is generated under the router path. (The build needs `@0gfoundation/ask-ai-widget`, which isn't installable locally — that module-resolution failure is pre-existing and unrelated, so it was stubbed locally to let the build complete. Nothing about the stub is committed.)
- Every configuration value in the page was exercised against `router-api.0g.ai`, and the request shapes were confirmed by logging what Claude Code actually sends per slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/359)
<!-- Reviewable:end -->
