### PR TITLE
chore(config): migrate broken markdown link hook

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -20,7 +20,11 @@ const config: Config = {
 
   trailingSlash: false,
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   i18n: {
     defaultLocale: 'en',


### PR DESCRIPTION
# Pull Request

## Description
<!-- Brief description of your changes -->

Move `onBrokenMarkdownLinks: 'warn'` from the deprecated top-level Docusaurus config key to `markdown.hooks`. The warning policy is unchanged; this only adopts the supported v4 configuration shape.



## Related Issue
Fixes #<!-- issue number -->

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [x] Tested locally with `yarn start`
- [x] Build passes with `yarn build`
- [ ] Links work correctly

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/362)
<!-- Reviewable:end -->
