### PR TITLE
fix: align network names in deploy-contracts (Hardhat/Foundry/Truffle)

### DIFF
--- a/docs/developer-hub/building-on-0g/contracts-on-0g/deploy-contracts.md
+++ b/docs/developer-hub/building-on-0g/contracts-on-0g/deploy-contracts.md
@@ -126,8 +126,8 @@ networks: {
 
 // For Foundry
 [rpc_endpoints]
-0g_testnet = "https://evmrpc-testnet.0g.ai"
-0g_mainnet = "https://evmrpc.0g.ai"
+testnet = "https://evmrpc-testnet.0g.ai"
+mainnet = "https://evmrpc.0g.ai"
 ```
 
 **Deploy Using Your Preferred Tool**:
@@ -151,7 +151,7 @@ main().catch((error) => {
 });
 ```
 
-Run: `npx hardhat run scripts/deploy.js --network 0g-testnet`
+Run: `npx hardhat run scripts/deploy.js --network testnet`
 
 </details>
 
@@ -178,7 +178,7 @@ module.exports = function (deployer) {
 };
 ```
 
-Run: `truffle migrate --network 0g-testnet`
+Run: `truffle migrate --network testnet`
 
 </details>
 


### PR DESCRIPTION
## Summary

Fixes a reported inconsistency on the [Deploy Smart Contracts on 0G Chain](https://docs.0g.ai/developer-hub/building-on-0g/contracts-on-0g/deploy-contracts#step-3-deploy-the-contract-on-0g-chain) page: the Step 3 config block used three different names for the same networks.

- Hardhat config defined `"testnet"` / `"mainnet"`
- Foundry `[rpc_endpoints]` used `0g_testnet` / `0g_mainnet`
- The Hardhat and Truffle run commands used `--network 0g-testnet` — a name defined in **neither** config, so copy-pasting the commands failed with an unknown-network error

Everything is now aligned to `testnet` / `mainnet`, matching the page's own Step 4 verify config and the canonical example in `docs/ai-context.md`.

## Changes

- Foundry `[rpc_endpoints]` renamed to `testnet` / `mainnet`
- Hardhat run command: `--network 0g-testnet` → `--network testnet`
- Truffle run command: `--network 0g-testnet` → `--network testnet`

No RPC URLs or chain IDs changed, so `docs/ai-context.md` needs no update.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/363)
<!-- Reviewable:end -->
