### PR TITLE
chore(ci): fold link check into build job — stop building the site twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,41 +60,15 @@ jobs:
         fi
         echo "Build successful ✅"
 
-  link-checker:
-    name: Check Links
-    runs-on: ubuntu-latest
-    needs: build-and-test
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Setup pnpm
-      # Version comes from package.json's "packageManager" field — don't also
-      # set `version` here or action-setup errors with ERR_PNPM_BAD_PM_VERSION.
-      uses: pnpm/action-setup@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '24.x'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-
-    - name: Build site
-      run: pnpm build
-    
+    # Reuses the build/ directory from the step above — keep this in the same
+    # job so the site isn't built twice.
     - name: Serve site and check links
       run: |
-        npm install -g broken-link-checker serve
-
         # Mirror Vercel routing locally: cleanUrls + redirects from vercel.json
         # (serve rejects the $schema field and the `has` header directive, so strip both)
         jq 'del(.["$schema"]) | .headers |= map(select(.has == null))' vercel.json > /tmp/serve.json
 
-        serve build -p 3000 -c /tmp/serve.json > /tmp/serve.log 2>&1 &
+        npx --yes serve build -p 3000 -c /tmp/serve.json > /tmp/serve.log 2>&1 &
         SERVER_PID=$!
 
         # Wait for serve to accept connections
@@ -103,7 +77,7 @@ jobs:
           sleep 1
         done
 
-        BLC_OUT=$(blc http://localhost:3000 --recursive --exclude-external 2>&1 || true)
+        BLC_OUT=$(npx --yes --package broken-link-checker blc http://localhost:3000 --recursive --exclude-external 2>&1 || true)
         BROKEN=$(echo "$BLC_OUT" | grep -c "BROKEN" || true)
         UNIQUE=$(echo "$BLC_OUT" | grep "BROKEN" | sort -u || true)
 


### PR DESCRIPTION
## Summary

The **Check Links** job was ~1m31s of wall time chained behind **Build and Test** (`needs:`), yet almost none of it was link checking. Step timings from a recent run ([32869168452](https://github.com/0gfoundation/0g-doc/actions/runs/32869168452)):

| Step | Time |
|---|---|
| Checkout + pnpm/Node setup | ~19s |
| `pnpm install` | ~10s |
| **`pnpm build` (duplicate)** | **~42s** |
| Serve + crawl links | ~16s |

The job re-did checkout, install, and a full second Docusaurus build just to serve output the first job had already produced. Total CI wall time was ~3 minutes serial.

## Change

- Moved the serve-and-check-links step to the end of the **Build and Test** job, reusing its `build/` directory — the duplicate checkout/install/build and the job-queue hop are gone.
- Replaced the per-run `npm install -g broken-link-checker serve` with `npx --yes` invocations.
- The check logic itself (Vercel routing emulation via `jq`-filtered `vercel.json`, `blc --recursive --exclude-external`, step-summary output, failure on broken links) is unchanged.

Expected CI wall time: ~3m → ~1m45s.

## Notes

- The standalone **Check Links** status check disappears; link failures now fail **Build and Test**. The `main` ruleset has no required-status-checks rule, so nothing needs updating in repo settings.
- `AGENTS.md`'s local-repro instructions still match — the serve/blc commands are identical, just relocated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/364)
<!-- Reviewable:end -->
