### PR TITLE
docs: update testnet fine-tuning contract address to fine-tuning-v1.1

### DIFF
--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -70,7 +70,9 @@ This page provides comprehensive context about 0G infrastructure to help AI codi
 | **WrappedOGBase** | `0x0000000000000000000000000000000000001001` | Wrapped native token (precompile) |
 | **Compute Ledger** | `0xE70830508dAc0A97e6c087c75f402f9Be669E406` | Compute network payment ledger |
 | **Compute Inference** | `0xa79F4c8311FF93C06b8CfB403690cc987c93F91E` | Compute inference service |
-| **Compute FineTuning** | `0xaC66eBd174435c04F1449BBa08157a707B6fa7b1` | Compute fine-tuning service |
+| **Compute FineTuning** | `0xC6C075D8039763C8f1EbE580be5ADdf2fd6941bA` | Compute fine-tuning service (`fine-tuning-v1.1`) |
+
+The previous testnet fine-tuning contract (`0xaC66eBd174435c04F1449BBa08157a707B6fa7b1`, registered as `fine-tuning-v1.0`) is still deployed and still registered on the Ledger, but it runs an older ABI. Use `fine-tuning-v1.1` for new integrations; historical indexers covering data before 2026-02-12 still need the old address.
 
 ### Mainnet Contracts
 


### PR DESCRIPTION
## What

`docs/ai-context.md` listed the testnet **Compute FineTuning** contract as `0xaC66eBd174435c04F1449BBa08157a707B6fa7b1`. That address was registered as `fine-tuning-v1.0` on 2025-11-19. Fine-tuning **v1.1** was deployed and registered on 2026-02-12 at `0xC6C075D8039763C8f1EbE580be5ADdf2fd6941bA` — which is what the SDK (`src.ts/sdk/constants.ts`) points at.

## Why the old address gets a footnote instead of just being deleted

The old contract is **not dead**. Verified on chain:

- `0xaC66…` is still deployed and still registered on the testnet Ledger under the name `fine-tuning-v1.0` (`getAllActiveServices()` returns it).
- Its implementation was never upgraded (0 `Upgraded` events on its beacon), so it runs the original **5-event** ABI, versus v1.1's **16 events** (which added the full deliverable lifecycle: `DeliverableAdded` / `Acknowledged` / `Abandoned` / `Evicted`, `FeesSettled`).

So an integrator who finds `0xaC66…` live on chain isn't looking at a stale doc — they're looking at a real, registered, older-ABI contract. The footnote says which one to use and flags that historical indexers covering data before 2026-02-12 need both.

Reported by an ecosystem team building an indexing platform, who hit exactly this confusion between the docs and the SDK.

## Not changed

Mainnet is unaffected — fine-tuning has only ever had one mainnet address (`0x4e3474095518883744ddf135b7E0A23301c7F9c0`), and the table already had it right. Testnet Ledger and Inference addresses are also already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/365)
<!-- Reviewable:end -->
