### PR TITLE
docs(router): document provider identity pinning (X-0G-Provider-Identity)

### DIFF
--- a/docs/developer-hub/building-on-0g/compute-network/router/models.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/models.md
@@ -54,6 +54,8 @@ curl "https://router-api.0g.ai/v1/providers?model=zai-org/GLM-5-FP8"
 
 Returns every TEE-acknowledged provider serving that model, with on-chain address, observed latency, and TEE attestation info. Use these addresses with the [`X-0G-Provider-Address` header](./routing) if you want deterministic routing.
 
+Each entry also carries `provider_identity` — the operator-declared name of the upstream channel serving that endpoint (for example `aliyun` or `openrouter`). It is a routing label, not an attested property; `verifiability` remains the trust signal. Endpoints serving a model through a single native channel omit the field. To route by channel, use the [`X-0G-Provider-Identity` header](./routing#header-reference) — it filters candidates rather than pinning one endpoint unless combined with an address. Independently of any pin, your usage history records which identity served each request.
+
 Query parameters:
 
 | Field          | Description                                                        |

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -102,7 +102,28 @@ curl https://router-api.0g.ai/v1/chat/completions \
   }'
 ```
 
-Routes directly to a specific provider by on-chain address. **Fallback is disabled by default when pinning** — if the pinned provider fails, the request fails. Add `X-0G-Provider-Allow-Fallbacks: true` to re-enable cross-provider retry.
+Routes directly to a specific provider by on-chain address. **Fallback is disabled by default when pinning by address** — if the pinned provider fails, the request fails. Add `X-0G-Provider-Allow-Fallbacks: true` to re-enable cross-provider retry.
+
+</TabItem>
+<TabItem value="identity" label="Pin an Upstream (identity)">
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -H "X-0G-Provider-Identity: aliyun" \
+  -d '{
+    "model": "glm-5.2",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+Some models are served through more than one upstream channel. `provider_identity` is the operator-declared name of that channel (for example `aliyun`, `zhipu`, `openrouter`) — a routing label, not an attested property (`verifiability` remains the trust signal). It is shown per endpoint on [`GET /v1/providers`](./models#listing-providers-for-a-model) and matched verbatim (case-sensitive). The header works in two modes:
+
+- **Alone** — a filter, not a pin: it narrows the candidates for the model to every endpoint carrying that identity, possibly across several providers, then the normal ranking (your [`X-0G-Provider-Sort`](#header-reference) choice) picks among them. Fallback stays enabled but only across the matching endpoints — it never spills over to other identities.
+- **Combined with `X-0G-Provider-Address`** — pins the exact upstream variant under that provider address, and inherits the address pin's `Allow-Fallbacks: false` default.
+
+An identity that matches no endpoint fails deterministically, rejected with `400 provider_model_mismatch` — never a silent fallback to unfiltered routing. Other routing filters compose after the identity filter: if the identity's endpoints exist but none matches a requested [trust mode](#trust-modes), the request fails with `503 no_provider_for_trust_mode` instead. Endpoints that serve a model through a single native channel carry no identity (the field is omitted on `/v1/providers`); pin those by address.
 
 </TabItem>
 <TabItem value="multipart" label="Multipart (audio / image edit)">
@@ -144,6 +165,7 @@ HTTP header names are case-insensitive per RFC 7230 — `X-0G-Provider-Address` 
 | Header                          | Values                              | Description                                                                                                  |
 | ------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `X-0G-Provider-Address`         | on-chain address (`0x…`)            | Pin the request to a specific provider. Implies `Allow-Fallbacks: false` unless overridden.                  |
+| `X-0G-Provider-Identity`        | upstream channel name (e.g. `aliyun`) | Route to a named upstream channel. Alone it filters candidates to that identity and normal ranking picks among them; with `X-0G-Provider-Address` it pins the exact variant and inherits `Allow-Fallbacks: false`. An identity matching no endpoint is rejected with `400 provider_model_mismatch`. |
 | `X-0G-Provider-Sort`            | `latency` \| `price`                | Sort strategy when no address is pinned. Ignored if `X-0G-Provider-Address` is set. Must be exactly `latency` or `price` — any other non-empty value is rejected with `400 invalid_provider_header`. |
 | `X-0G-Provider-Trust-Mode`      | `standard` \| `verified` \| `private` | Restrict provider selection to a trust tier — see [Trust modes](#trust-modes).                                |
 | `X-0G-Provider-Allow-Fallbacks` | `true` \| `false`                   | Allow cross-provider retry on failure. Must be exactly `true` or `false` (case-insensitive) — `1`, `0`, `yes`, and other non-empty values are rejected with `400 invalid_provider_header`. |


### PR DESCRIPTION
Documents the provider identity pinning surface that shipped in 0g-router #763-#768 (requested by Aya in the #devrel-ecosystem docs thread).

**routing.md**
- New "Pin an Upstream (identity)" tab: `X-0G-Provider-Identity` with a live-verified example (`glm-5.2` via `aliyun`), the two modes (identity-only = filter + normal ranking, fallback only across matching endpoints; combined with `X-0G-Provider-Address` = exact variant, inherits `Allow-Fallbacks: false`), the deterministic `400 provider_model_mismatch` on a bad pin, and how it composes with trust modes (`503 no_provider_for_trust_mode` when the tier filter empties the identity's endpoints).
- `X-0G-Provider-Identity` row in the Header Reference table.
- Scoped the existing fallback sentence in the address tab to "when pinning by address" (identity-only pinning keeps fallbacks on, per `route_options.go`).

**models.md**
- "Listing Providers for a Model" now describes the `provider_identity` field: routing label (not a trust signal), omitted for single-native-channel endpoints, and the usage-history exposure.

Every claim is verified against 0g-router HEAD (`route_options.go`, `provider.go` routeCandidates/filterEmptyError, `response/types.go` omitempty) and the live `GET /v1/providers?model=glm-5.2` response. Wording reviewed by a multi-model pass before opening.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/369)
<!-- Reviewable:end -->
