### PR TITLE
docs: pick up the four copy fixes from #186 that still apply

### DIFF
--- a/docs/concepts/compute.md
+++ b/docs/concepts/compute.md
@@ -89,7 +89,7 @@ Built-in redundancy:
 <details>
 <summary>**Can I run proprietary models?**</summary>
 
-Yes. Upload any model, set requirements and pricing, start serving requests. Perfect for specialized use cases.
+Yes. Upload any model, set requirements and pricing, and start serving requests. Perfect for specialized use cases.
 
 </details>
 

--- a/docs/concepts/da.md
+++ b/docs/concepts/da.md
@@ -23,7 +23,7 @@ However, it's worth noting that not all DALs are built equally.
 
 ## The Challenge Today
 
-Existing DALs tend to require that data be simultaneously sent to all of their network nodes, preventing horizontal scalability and limiting network speed to its slowest node. They also do not have built-in storage systems, requiring connectivity to external systems that impact throughput, latency, and cost. 
+Existing DALs tend to require that data be simultaneously sent to all of their network nodes, preventing horizontal scalability and limiting network speed to the slowest node. They also do not have built-in storage systems, requiring connectivity to external systems that impact throughput, latency, and cost. 
 
 Additionally, 0G inherits Ethereum's security, while other systems rely upon their own security mechanisms that fall short. This is significant because Ethereum's network is secured by over 34 million ETH staked, representing approximately $80 billion in cryptoeconomic security at the time of writing. In contrast, competitors rely on security mechanisms that, at best, represent only a fraction of Ethereum's total security. This gives 0G a distinct advantage, as it leverages the vast economic incentives and decentralization of Ethereum's staking system, providing a level of protection that competitors cannot match.
 
@@ -67,7 +67,7 @@ The consensus mechanism used by 0G is fast and efficient due to its sampling-bas
 
 Validators in the 0G Consensus network, who are separate from the DA nodes, verify and finalize these proofs. Although DA nodes ensure data availability, they do not directly participate in the final consensus process, which is the responsibility of 0G validators. Validators use a shared staking mechanism where they stake 0G tokens on a primary network (likely Ethereum). Any slashable event across connected networks leads to slashing on the main network, securing the system's scalability while maintaining robust security. 
 
-This is a key mechanism that allows for the system to scale infinitely while maintaining data availability. In return, validators engaged in shared staking receive 0G tokens on any network managed, which can then be burnt in return for 0G tokens on the mainnet.
+This is a key mechanism that allows the system to scale infinitely while maintaining data availability. In return, validators engaged in shared staking receive 0G tokens on any network managed, which can then be burnt in return for 0G tokens on the mainnet.
 
 <div style={{textAlign: 'center'}}>
   <img src="/img/consensus process.png" alt="0G DA Consensus Process" style={{maxWidth: '100%'}} />

--- a/docs/developer-hub/building-on-0g/da-integration.md
+++ b/docs/developer-hub/building-on-0g/da-integration.md
@@ -229,7 +229,7 @@ cargo run -r -p server --features grpc/parallel,grpc/cuda -- --config run/config
 If you do not have a CUDA environment, remove the cuda feature.
 :::
 
-DA Encoder will serve on port 34000 with specified gRPC interface.
+DA Encoder will serve on port 34000 with the specified gRPC interface.
 
 ## Using the Verification Logic
 


### PR DESCRIPTION
# Pull Request

## Description
Four one-word copy fixes carried over from #186 (by @consensuslayer), which was closed because the rest of its edits targeted pages that have since been rewritten or moved.

- `concepts/compute.md`: "set requirements and pricing, and start serving requests"
- `concepts/da.md`: "limiting network speed to the slowest node"
- `concepts/da.md`: "allows the system to scale infinitely"
- `developer-hub/building-on-0g/da-integration.md`: "with the specified gRPC interface"

## Related Issue
Supersedes #186

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [x] Text-only change, no links or structure touched

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/371)
<!-- Reviewable:end -->
