### PR TITLE
fix(search): keep the shortcut hint hidden on small screens (follow-up to #290)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -58,30 +58,39 @@
   color: #666;
 }
 
-/* Keep keyboard shortcut icons inside the search field */
-.navbar__search [class*='searchHintContainer'],
-.navbar__search .DocSearch-Button-Keys {
-  position: absolute;
-  right: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  margin: 0;
-  pointer-events: none;
+/* Keep keyboard shortcut icons inside the search field (desktop only: the search
+   plugin hides the hint and shrinks the input to an icon below 576px) */
+@media (min-width: 577px) {
+  .navbar__search [class*='searchHintContainer'],
+  .navbar__search .DocSearch-Button-Keys {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  .navbar__search [class*='searchHintContainer'] kbd,
+  .navbar__search [class*='searchHint'],
+  .navbar__search .DocSearch-Button-Key {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    line-height: 1;
+  }
 }
 
-.navbar__search [class*='searchHintContainer'] kbd,
-.navbar__search [class*='searchHint'],
-.navbar__search .DocSearch-Button-Key {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 20px;
-  height: 20px;
-  padding: 0 6px;
-  line-height: 1;
+@media (max-width: 576px) {
+  .navbar__search-input {
+    padding-right: 16px;
+  }
 }
 
 /* GitHub icon */


### PR DESCRIPTION
# Pull Request

## Description
Follow-up to #290 (by @anurag-p6), which positions the `ctrl K` / `⌘ K` hint inside the navbar search input on desktop.

The search plugin (`@easyops-cn/docusaurus-search-local`, `SearchBar.module.css`) hides `.searchHintContainer` and shrinks the input to a 2rem icon at `max-width: 576px`. The new `.navbar__search [class*='searchHintContainer']` selectors have higher specificity than that media rule, so on phones the pill showed `ctrl K` with no placeholder and 64px of right padding.

This wraps the #290 rules in `@media (min-width: 577px)` and restores `padding-right: 16px` on the input below that, so the mobile icon pill is identical to before #290 while desktop and tablet keep the fix.

Verified locally with a Windows UA at 500 / 800 / 1440px: 500px shows the lone magnifier pill with the hint hidden; 800px shows `Search` and `ctrl K` without overlap; 1440px shows the keys inset inside the pill.

## Related Issue
Closes #289

## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Style/UI change

## Testing
- [x] Tested locally with `pnpm start` at 500 / 800 / 1440px, Windows and macOS user agents

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/372)
<!-- Reviewable:end -->
