### PR TITLE
docs(ai-context): fix the fine-tuning CLI block (wrong commands and flags)

### DIFF
--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -402,18 +402,33 @@ client = OpenAI(
 
 **Fine-tuning Models** (uses the Direct account system; not available via Router):
 ```bash
-# Prepare dataset (JSONL format, one {"prompt": "...", "completion": "..."} per line)
-0g-compute-cli fine-tuning upload-data --file dataset.jsonl
+# Dataset: JSONL, one object per line, in one of the supported formats:
+# {"instruction","input","output"}, chat {"messages":[...]}, or plain {"text"}
 
-# Create fine-tuning task (fund the fine-tuning sub-account first: transfer-fund --service fine-tuning)
+# Fund the provider's fine-tuning sub-account first (--service fine-tuning is required)
+0g-compute-cli transfer-fund --provider <PROVIDER_ADDRESS> --amount 2 --service fine-tuning
+
+# Create a task from a local dataset (uploaded automatically) and a training config
 0g-compute-cli fine-tuning create-task \
+  --provider <PROVIDER_ADDRESS> \
   --model Qwen2.5-0.5B-Instruct \
-  --dataset <DATASET_ID> \
-  --provider <PROVIDER_ADDRESS>
+  --dataset-path dataset.jsonl \
+  --config-path config.json
 
-# Monitor progress
-0g-compute-cli fine-tuning get-task --task-id <TASK_ID>
+# Or upload once and reuse the root hash with --dataset <ROOT_HASH>
+0g-compute-cli fine-tuning upload --data-path dataset.jsonl
+
+# Monitor progress (omit --task to get the latest task)
+0g-compute-cli fine-tuning get-task --provider <PROVIDER_ADDRESS> --task <TASK_ID>
+
+# When status is Delivered: download and acknowledge within 48 hours (--data-path is a file, not a directory)
+0g-compute-cli fine-tuning acknowledge-model --provider <PROVIDER_ADDRESS> --task-id <TASK_ID> --data-path ./encrypted_model.bin
+
+# When status is Finished: decrypt to a zip containing the LoRA adapter
+0g-compute-cli fine-tuning decrypt-model --provider <PROVIDER_ADDRESS> --task-id <TASK_ID> --encrypted-model ./encrypted_model.bin --output ./model.zip
 ```
+
+Fine-tuning base models: `Qwen2.5-0.5B-Instruct` (mainnet and testnet), `Qwen3-32B` (mainnet only). Check the live list with `0g-compute-cli fine-tuning list-models`.
 
 **Documentation Links**:
 - Overview: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/overview](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/overview)


### PR DESCRIPTION
# Pull Request

## Description
The fine-tuning block in `docs/ai-context.md` (the page AI assistants are pointed at) had three errors, verified against `0g-compute-ts-sdk` `src.ts/cli/fine-tuning.ts`:

- `fine-tuning upload-data --file` does not exist; the command is `fine-tuning upload --data-path <path>`.
- `get-task --task-id` is wrong; it is `get-task --provider <address> --task <id>` (`--provider` is required, `--task` defaults to the latest task).
- The `{"prompt", "completion"}` dataset format is not one of the three supported formats (instruction/input/output, chat messages, plain text).

Rewritten to mirror the flow on the fine-tuning page: fund the fine-tuning sub-account, `create-task --dataset-path --config-path` (or `upload` then `--dataset <hash>`), `get-task`, `acknowledge-model` (file path, 48 hour window), `decrypt-model`. Adds the per-network base model note (`Qwen3-32B` is mainnet only; checked live with `fine-tuning list-models` on both networks).

## Related Issue
Part of #367 (section 1)

## Type of Change
- [x] Documentation update

## Testing
- [x] Every command and flag checked against the CLI source
- [x] Text-only change inside a code block

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/373)
<!-- Reviewable:end -->
