### PR TITLE
docs: rewrite README and align CONTRIBUTING setup with pnpm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@ By participating in this project, you agree to abide by our community standards:
 
 ### Prerequisites
 
-- Node.js >= 18.0.0
-- Yarn, npm, or pnpm package manager
+- Node.js 24 (`nvm use` picks it up from `.nvmrc`; minimum 22)
+- pnpm 11, pinned via the `packageManager` field (run `corepack enable` once; do not use yarn or npm)
 - Git
 - Basic knowledge of Markdown and React (for advanced contributions)
 
@@ -41,17 +41,17 @@ By participating in this project, you agree to abide by our community standards:
 
 2. **Install Dependencies**
    ```bash
-   yarn install
+   pnpm install --frozen-lockfile
    ```
 
 3. **Start Development Server**
    ```bash
-   yarn start
+   pnpm start
    ```
 
 4. **Build and Test**
    ```bash
-   yarn build
+   pnpm build
    ```
 
 ## 📝 Contribution Types

--- a/README.md
+++ b/README.md
@@ -1,27 +1,60 @@
-# Visit the Official 0G Docs Website
+# 0G Documentation
 
-If you want to learn more about 0G, visit the [0G Docs](https://docs.0g.ai/)
+Source for [docs.0g.ai](https://docs.0g.ai), the documentation for 0G: chain, storage, data availability, compute, and the developer hub. Built with [Docusaurus 3](https://docusaurus.io) and deployed on Vercel.
 
-# Contributing to 0G Docs
+## Quick start
 
-### Installation
+Requirements: Node 24 (pinned in `.nvmrc`, minimum 22 per `package.json`) and pnpm 11 (pinned via the `packageManager` field; do not use yarn or npm, the lockfile is `pnpm-lock.yaml`).
 
-```
-$ yarn
-```
-
-### Local Development
-
-```
-$ yarn start
+```bash
+nvm use                          # picks up .nvmrc
+corepack enable                  # activates the pinned pnpm
+pnpm install --frozen-lockfile   # same as CI
+pnpm start                       # dev server with live reload
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+Other commands:
 
-### Build
-
+```bash
+pnpm build       # production build into build/; fails on broken internal links
+pnpm serve       # serve the built site
+pnpm typecheck   # TypeScript check (CI runs this)
+pnpm clear       # clear the Docusaurus cache when builds get weird
 ```
-$ yarn build
-```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+If `pnpm install` aborts with `ERR_PNPM_IGNORED_BUILDS` or a blocked git dependency, see the pnpm notes in [AGENTS.md](AGENTS.md): the fixes live in `pnpm-workspace.yaml` and must not be removed.
+
+## Repository layout
+
+| Path | What it is |
+|------|------------|
+| `docs/` | All content, as Markdown/MDX. A file at `docs/concepts/chain.md` is served at `/concepts/chain` (docs are at the site root, not under `/docs`). |
+| `sidebars.ts` | Hand-curated sidebar. Adding, moving, or renaming a doc requires an update here. |
+| `src/` | Site code: custom CSS, React components (for example the add-network wallet buttons), and Docusaurus plugins. |
+| `static/` | Static assets copied as is (images, animations, `robots.txt`). |
+| `docusaurus.config.ts` | Site configuration, navbar, footer, plugins, analytics gating. |
+| `vercel.json` | Production redirects and security headers. Old URLs that move need a redirect here. |
+| `.cspell.json` | Project dictionary for the spell check that runs in CI. New product or protocol terms go in `words`. |
+| `docs/ai-context.md` | Consolidated network configs, addresses, SDK names, and endpoints for AI coding assistants. Keep it in sync when those change anywhere else. |
+
+The site also publishes every page as raw Markdown (append `.md` to a page URL) plus `llms.txt` and `llms-full.txt` at the root, for LLM tooling.
+
+## Contributing
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution process, writing guidelines, and review expectations. [AGENTS.md](AGENTS.md) holds the working notes that both humans and AI coding agents rely on: commands, architecture, conventions, and deployment details.
+
+Open pull requests from a feature branch into `main`, one change per PR. CI builds the site, checks links against production routing, and runs the spell check.
+
+## Deployments
+
+| Branch | Environment |
+|--------|-------------|
+| `main` | Production, [docs.0g.ai](https://docs.0g.ai) |
+| `staging` | [staging.docs.0g.ai](https://staging.docs.0g.ai), a preview environment kept `noindex`; not a release source |
+| any PR | Ephemeral Vercel preview URL |
+
+## Community
+
+- [Discord](https://discord.gg/0glabs)
+- [X](https://x.com/0g_Labs)
+- [GitHub issues](https://github.com/0gfoundation/0g-doc/issues) for documentation bugs and requests


### PR DESCRIPTION
# Pull Request

## Description
Tracked in #367 (section 6). The README was 26 lines, still said `yarn` / `yarn start` / `yarn build`, and explained nothing about the repo. The project is pinned to pnpm 11 via `packageManager` with a committed `pnpm-lock.yaml` (AGENTS.md already noted the mismatch), so a newcomer following the README created a stray `yarn.lock` and never saw the pnpm 10+ gotchas.

New README covers: requirements (Node 24 from `.nvmrc`, pnpm via `corepack enable`), the quick start and the other scripts, a repository layout table (`docs/`, `sidebars.ts`, `src/`, `static/`, `docusaurus.config.ts`, `vercel.json`, `.cspell.json`, `docs/ai-context.md`), the raw Markdown / `llms.txt` endpoints, pointers to CONTRIBUTING.md and AGENTS.md, the branch-to-environment table, and community links.

CONTRIBUTING.md gets the matching four-line fix in Prerequisites and Local Development Setup (`Node.js >= 18` and `yarn` were both stale).

The license line is intentionally left out until #367 section 5 (LICENSE) is decided.

## Related Issue
Part of #367

## Type of Change
- [x] Documentation update

## Testing
- [x] Commands match `package.json` scripts and the CI workflow
- [x] No site content touched; build unaffected

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/375)
<!-- Reviewable:end -->
