### PR TITLE
docs: add dRPC to the third-party RPC provider lists

### DIFF
--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -34,6 +34,7 @@ This page provides comprehensive context about 0G infrastructure to help AI codi
 - QuickNode: https://www.quicknode.com/chains/0g
 - ThirdWeb: https://thirdweb.com/0g-galileo-testnet-16601
 - Ankr: https://www.ankr.com/rpc/0g/
+- dRPC: https://drpc.org/chainlist/0g-galileo-testnet-rpc
 - dRPC NodeCloud: https://drpc.org/chainlist/0g-galileo-testnet-rpc
 
 ### Mainnet (Aristotle)
@@ -55,6 +56,7 @@ This page provides comprehensive context about 0G infrastructure to help AI codi
 - QuickNode: https://www.quicknode.com/chains/0g
 - ThirdWeb: https://thirdweb.com/0g-aristotle
 - Ankr: https://www.ankr.com/rpc/0g/
+- dRPC: https://drpc.org/chainlist/0g-mainnet-rpc
 
 ## Smart Contract Addresses
 

--- a/docs/developer-hub/mainnet/mainnet-overview.md
+++ b/docs/developer-hub/mainnet/mainnet-overview.md
@@ -32,6 +32,7 @@ Build and run production workloads on the 0G Mainnet.
 - [QuickNode](https://www.quicknode.com/chains/0g)
 - [ThirdWeb](https://thirdweb.com/0g-aristotle)
 - [Ankr](https://www.ankr.com/rpc/0g/)
+- [dRPC](https://drpc.org/chainlist/0g-mainnet-rpc)
 
 ### Add Network to Wallet
 


### PR DESCRIPTION
# Pull Request

## Description
The testnet overview already lists dRPC NodeCloud as a third-party RPC; the mainnet overview and both provider lists in `docs/ai-context.md` did not. Adds:

- Mainnet: https://drpc.org/chainlist/0g-mainnet-rpc
- Testnet (ai-context list): https://drpc.org/chainlist/0g-galileo-testnet-rpc

Both pages return 200.

## Related Issue
Replaces #379 (moved from the fork so Vercel builds the preview).

## Type of Change
- [x] Documentation update

## Testing
- [x] Links checked live

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/381)
<!-- Reviewable:end -->
