### PR TITLE
docs(glossary): drop the deAIOS entry

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -387,7 +387,6 @@
     "monitoring",
     "frontmatter",
     "aios",
-    "deaios",
     "solana",
     "teeml",
     "teetls",

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -25,8 +25,6 @@ A comprehensive list of technical terms used throughout the 0G documentation.
 
 **DA (Data Availability)**: A layer that ensures data required by blockchain applications is available when needed, crucial for scalability and security.
 
-**deAIOS**: Legacy term for the 0G stack, short for Decentralized AI Operating System. 0G now describes itself as the trust layer for AI: private compute, encrypted storage, and an AI-native EVM L1 chain in one stack. The older term still appears in earlier material.
-
 **Decentralized Storage**: A storage system that distributes data across multiple nodes rather than relying on centralized servers.
 
 ## E


### PR DESCRIPTION
# Pull Request

## Description
`deAIOS` was retired from every page in #380; the glossary entry (kept there as a legacy definition) was the last occurrence in the repo and nothing else uses the word. Remove it and the spell-check dictionary entry, so `llms-full.txt` carries no retired phrase at all.

## Type of Change
- [x] Documentation update

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/382)
<!-- Reviewable:end -->
