### PR TITLE
chore(context7): add the claim url and public key

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/0gfoundation/0g-doc",
+  "public_key": "pk_VR4gu96VQ3puUw2ZTwaQm",
   "projectTitle": "0G Documentation",
   "description": "Official technical documentation for 0G, the trust layer for AI: private compute, encrypted storage, an AI-native EVM L1 chain, data availability, and Agentic IDs. Source of https://docs.0g.ai.",
   "folders": ["docs"],


### PR DESCRIPTION
# Pull Request

## Description
Context7's claim flow requires `url` and `public_key` in `context7.json` on the default branch before the "Claim Library" button verifies ownership. Adds the two fields it generated for `0gfoundation/0g-doc`; the public key is not a secret. Everything else in the file is unchanged.

## Type of Change
- [x] Documentation update

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/384)
<!-- Reviewable:end -->
