### PR TITLE
chore(context7): serve the website-entry claim file at /context7.json

### DIFF
--- a/static/context7.json
+++ b/static/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/0g_ai",
+  "public_key": "pk_VR4gu96VQ3puUw2ZTwaQm"
+}


### PR DESCRIPTION
# Pull Request

## Description
Context7 verifies ownership of the `/websites/0g_ai` entry (the stale April scrape of the site) through a publicly reachable `https://docs.0g.ai/context7.json` containing the entry URL and the public key it generated. Adds that file under `static/`. Once claimed, the scrape can be redirected to the repo-backed `/0gfoundation/0g-doc` entry so agents stop getting four-month-old content. The public key is not a secret.

## Type of Change
- [x] Documentation update

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/385)
<!-- Reviewable:end -->
