### PR TITLE
docs(storage): replace the erasure-coding claim with Merkle-root verification and PoRA replication

### DIFF
--- a/docs/concepts/da.md
+++ b/docs/concepts/da.md
@@ -52,7 +52,7 @@ These differentiators make 0G uniquely positioned to tackle the challenges of sc
 
 ## How Does This Work?
 
-As covered in [0G Storage](./storage.md), data within the 0G ecosystem is first erasure-coded and split into "data chunks," which are then distributed across various Storage Nodes in the 0G Storage network. 
+Data submitted to 0G DA is first erasure-coded and split into "data chunks," which are then distributed across various Storage Nodes in the 0G Storage network. 
 
 To ensure data availability, 0G uses **Data Availability Nodes** that are randomly chosen using a Verifiable Random Function (VRF). A VRF generates random values in a way that is unpredictable yet verifiable by others, which is important as it prevents potentially malicious nodes from collusion.
 

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -61,8 +61,8 @@ Decentralized storage (like 0G):
 <summary><b>💾 Data Storage Lane</b></summary>
 
 - Manages actual data storage
-- Uses erasure coding: splits data into chunks with redundancy
-- Even if 30% of nodes fail, your data remains accessible
+- Every upload is committed on-chain as a Merkle root, so any node's copy can be verified against it
+- Durability comes from replication: many independent miners keep copies because PoRA pays them to
 - Automatic replication maintains availability
 </details>
 <img src="/img/0G Storage Architecture.png" alt="Storage Architecture" />
@@ -143,7 +143,7 @@ To promote fairness, the mining range is capped at 8 TB of data per mining opera
 | **IPFS** | Small files, hobby projects | Very slow, no guarantees |
 
 ### 0G's Unique Position
-- **Only solution** supporting both structured and unstructured data
+- Supports both structured and unstructured data
 - **Instant access** unlike other decentralized options
 - **Built for AI** from the ground up
 
@@ -152,7 +152,7 @@ To promote fairness, the mining range is capped at 8 TB of data per mining opera
 <details>
 <summary><b>Is my data really safe if nodes go offline?</b></summary>
 
-Yes! The erasure coding system ensures your data survives node failures. The network automatically maintains redundancy levels, so your data remains accessible even during significant outages.
+Yes. Your data is stored by many independent miners who are paid through PoRA to keep it, and every upload is committed on-chain as a Merkle root, so any copy can be verified. Individual node failures do not affect availability as long as other miners hold the data, which the incentives are designed to guarantee. Erasure coding is used by 0G DA, not by 0G Storage.
 </details>
 
 <details>


### PR DESCRIPTION
# Pull Request

## Description
Confirmed with the storage team on 2026-09-02 ahead of the KBW / Token2049 handout: 0G Storage does not erasure-code data; erasure coding is a 0G DA mechanism (see the DA deep dive). The Storage concept page said otherwise in two places and the DA page attributed it to Storage.

- `concepts/storage.md` storage-node bullets: erasure coding and the unsourced "30% of nodes fail" line replaced with on-chain Merkle-root verification and PoRA-incentivised replication.
- `concepts/storage.md` FAQ "Is my data really safe if nodes go offline?": rewritten on the same basis, with an explicit note that erasure coding belongs to DA.
- `concepts/da.md`: "As covered in 0G Storage, data is first erasure-coded" now says data submitted to 0G DA is erasure-coded.
- `concepts/storage.md` "Only solution supporting both structured and unstructured data": "only" dropped; the team is not sure the exclusivity still holds.

Not changed here, pending a decision: the "95% lower costs than AWS" claim (`storage.md:38`, `ai-context.md:204,207`). The team quoted the current price (11 0G per TB per month) rather than confirming the percentage.

## Type of Change
- [x] Documentation update

## Testing
- [x] Text-only change; no links or structure touched

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/386)
<!-- Reviewable:end -->
