### PR TITLE
docs(router): point the Claude Code config at glm-5.3

### DIFF
--- a/docs/developer-hub/building-on-0g/compute-network/router/clients/claude-code.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/clients/claude-code.md
@@ -22,12 +22,12 @@ and replace `YOUR_API_KEY` with a Router [API key](../authentication):
     "ANTHROPIC_AUTH_TOKEN": "YOUR_API_KEY",
     "ANTHROPIC_API_KEY": "",
 
-    "ANTHROPIC_MODEL": "glm-5.2",
-    "ANTHROPIC_DEFAULT_FABLE_MODEL": "glm-5.2",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.2",
+    "ANTHROPIC_MODEL": "glm-5.3",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL": "glm-5.3",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.3",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "0gm-1.0-35b-a3b",
 
-    "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "983616"
+    "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "1032192"
   },
   "modelOverrides": {
     "claude-sonnet-5": "0gm-1.0-35b-a3b"
@@ -58,7 +58,7 @@ client sends. See [Privacy & ZDR](../privacy#enabling-privacy-mode).
 - **`ANTHROPIC_DEFAULT_HAIKU_MODEL`** covers background work — session names for
   `claude --resume`, status for commands like `/usage`.
 - **`CLAUDE_CODE_MAX_CONTEXT_TOKENS`** is the main model's real context window. Without
-  it Claude Code assumes 200 K and compacts at a fifth of `glm-5.2`'s 1 M.
+  it Claude Code assumes 200 K and compacts at a fifth of `glm-5.3`'s 1 M.
 - **`--permission-mode auto`** is required per session, or set
   `{"permissions": {"defaultMode": "auto"}}` in `~/.claude/settings.json`. With an API
   key, sessions otherwise start in Manual mode.

--- a/docs/developer-hub/building-on-0g/compute-network/router/clients/claude-code.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/clients/claude-code.md
@@ -27,7 +27,7 @@ and replace `YOUR_API_KEY` with a Router [API key](../authentication):
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.3",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "0gm-1.0-35b-a3b",
 
-    "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "1032192"
+    "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "983616"
   },
   "modelOverrides": {
     "claude-sonnet-5": "0gm-1.0-35b-a3b"


### PR DESCRIPTION
`docs/.../router/clients/claude-code.md` handed out a `settings.json` pinned to `glm-5.2`. That model no longer advertises the Anthropic face — `GET /v1/models` returns `"supported_formats": ["openai"]` for it — so the documented config can't reach the Router over `/v1/messages`.

Swapped the three Anthropic model slots to `glm-5.3`, which does list `anthropic`, and is `"verifiability": "TeeML"` (the Private-mode tip below the block already asserted both models were TeeML — with 5.2, TeeTLS, that was wrong; now it's true).

`CLAUDE_CODE_MAX_CONTEXT_TOKENS` stays at 983616.

Left every other `glm-5.2` reference in the docs alone: those are OpenAI-format examples and the model is still live and listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/387)
<!-- Reviewable:end -->
