### PR TITLE
Read the Turnstile site key from TURNSTILE_SITE_KEY

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -20,6 +20,14 @@ const config: Config = {
 
   url: 'https://docs.0g.ai',
   baseUrl: '/',
+
+  // Build-time values exposed to the client. The Turnstile site key is public
+  // (it ships in the page) and must match a widget whose hostnames include
+  // docs.0g.ai. Set TURNSTILE_SITE_KEY in Vercel; the fallback is Cloudflare's
+  // always-pass test key for local development only.
+  customFields: {
+    turnstileSiteKey: process.env.TURNSTILE_SITE_KEY ?? '1x00000000000000000000AA',
+  },
   organizationName: '0G Labs',
   projectName: '0g-docs',
 

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,5 +1,6 @@
 import React, {type ReactNode} from 'react';
 import {AskAIWidget} from '@0gfoundation/ask-ai-widget';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import '@0gfoundation/ask-ai-widget/styles.css';
 
 // Docusaurus Root wrapper — renders once around every page, so each page gets
@@ -7,12 +8,14 @@ import '@0gfoundation/ask-ai-widget/styles.css';
 // build.0g.ai chat backend (0G Compute, same RAG knowledge index as
 // build.0g.ai/ask); docs.0g.ai is in that backend's CORS allowlist.
 export default function Root({children}: {children: ReactNode}): ReactNode {
+  const {siteConfig} = useDocusaurusContext();
+  const turnstileSiteKey = siteConfig.customFields?.turnstileSiteKey as string;
   return (
     <>
       {children}
       <AskAIWidget
         apiUrl="https://build.0g.ai/api/chat"
-        turnstileSiteKey="1x00000000000000000000AA"
+        turnstileSiteKey={turnstileSiteKey}
       />
     </>
   );


### PR DESCRIPTION
The Ask AI widget's Turnstile site key was hard-coded to Cloudflare's always-pass test key. build.0g.ai's chat route now verifies tokens against a real secret, so the docs chat fails with "Couldn't verify you're human" until docs.0g.ai presents the matching site key.

This reads TURNSTILE_SITE_KEY at build time via customFields and passes it to the widget. Local builds fall back to the test key.

Before merging: set TURNSTILE_SITE_KEY in the docs Vercel project (production and preview) and make sure docs.0g.ai is on the Turnstile widget's hostname list. Only the site key is needed here, the secret stays on the hub.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/388)
<!-- Reviewable:end -->
