### PR TITLE
docs(router): privacy-mode example model glm-5.2 -> glm-5.3 (TeeML upgrade follow-up)

### DIFF
--- a/docs/developer-hub/building-on-0g/compute-network/router/privacy.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/privacy.md
@@ -69,7 +69,7 @@ client = OpenAI(
 )
 
 completion = client.chat.completions.create(
-    model="glm-5.2",  # served by a TeeML provider
+    model="glm-5.3",  # served by a TeeML provider
     messages=[{"role": "user", "content": "Hello"}],
 )
 ```


### PR DESCRIPTION
One-line follow-up to the Sep 3 TeeML provider upgrade (announced by Aya in #0g-compute-all, shipped as https://0g.ai/blog/glm-5-3-teeml): the privacy-mode code example pinned `glm-5.2`, which no longer has a TeeML provider. Live `/v1/models` confirms `glm-5.3` is the TeeML GLM now (`glm-5.2` is TeeTLS-only). The generic routing examples elsewhere keep `glm-5.2` — still a valid model, no TeeML claim there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/389)
<!-- Reviewable:end -->
