### PR TITLE
Point the Ask AI widget at the chat backend on 0g.ai/zed

### DIFF
--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -5,8 +5,8 @@ import '@0gfoundation/ask-ai-widget/styles.css';
 
 // Docusaurus Root wrapper — renders once around every page, so each page gets
 // the floating "Ask AI" chat button (bottom-right). The widget talks to the
-// build.0g.ai chat backend (0G Compute, same RAG knowledge index as
-// build.0g.ai/ask); docs.0g.ai is in that backend's CORS allowlist.
+// Ask Zed chat backend at 0g.ai/zed (0G Compute, same RAG knowledge index
+// as build.0g.ai/ask); docs.0g.ai is in that backend's CORS allowlist.
 export default function Root({children}: {children: ReactNode}): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   const turnstileSiteKey = siteConfig.customFields?.turnstileSiteKey as string;
@@ -14,7 +14,7 @@ export default function Root({children}: {children: ReactNode}): ReactNode {
     <>
       {children}
       <AskAIWidget
-        apiUrl="https://build.0g.ai/api/chat"
+        apiUrl="https://0g.ai/zed/api/chat"
         turnstileSiteKey={turnstileSiteKey}
       />
     </>


### PR DESCRIPTION
The chat API has moved out of the Builder Hub to its own Vercel project, reached through the 0g.ai edge worker at https://0g.ai/zed/api/chat. Same streaming protocol and knowledge index, and docs.0g.ai is in the new backend's origin allowlist, so this is a URL change only on the existing widget pin (v0.1.0). Verified end to end from the widget demo against the new URL. Rollback is reverting this one line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/390)
<!-- Reviewable:end -->
